### PR TITLE
Don't allow changing duration if a joint does not have enough setpoints

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/JointSettingPlot.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/JointSettingPlot.py
@@ -110,6 +110,9 @@ class JointSettingPlot(pg.PlotItem):
 
         # Check for deletion
         if event.modifiers() == QtCore.Qt.ShiftModifier:
+            # Only allow deletion when there are more than 2 items left.
+            if len(self.plot_item.getData()[0]) <= 2:
+                return
             for item in self.dataItems:
                 new_pts = item.scatter.pointsAt(local_position)
                 if len(new_pts) >= 1:

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -273,7 +273,11 @@ class GaitGeneratorPlugin(Plugin):
         rescale_setpoints = self._widget.GaitPropertiesFrame.findChild(QCheckBox, "ScaleSetpoints").isChecked()
 
         if self.gait.has_setpoints_after_duration(duration) and not rescale_setpoints:
-
+            if not self.gait.has_multiple_setpoints_before_duration(duration):
+                QMessageBox.question(self._widget, 'Could not update gait duration',
+                                     "Not all joints have multiple setpoints before duration " + str(duration),
+                                     QMessageBox.Ok)
+                return
             discard_setpoints = QMessageBox.question(self._widget, 'Gait duration lower than highest time setpoint',
                                                      "Do you want to discard any setpoints higher than the given "
                                                      "duration?",

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -67,6 +67,16 @@ class Gait:
         rospy.logerr("Joint with name " + name + " does not exist in gait " + self.name + ".")
         return None
 
+    def has_multiple_setpoints_before_duration(self, duration):
+        for joint in self.joints:
+            count = 0
+            for setpoint in joint.setpoints:
+                if setpoint.time <= duration:
+                    count += 1
+            if count < 2:
+                return False
+        return True
+
     def has_setpoints_after_duration(self, duration):
         for joint in self.joints:
             for setpoint in joint.setpoints:


### PR DESCRIPTION
Closes #23 

The interpolation would crash when you have less than 2 setpoints. With this fix a warning is thrown when trying to discard setpoints if it would leave any joint with less than 2 setpoints. The action is then canceled.