### PR TITLE
Gait mirroring

### DIFF
--- a/march_rqt_gait_generator/config/layout.yaml
+++ b/march_rqt_gait_generator/config/layout.yaml
@@ -1,0 +1,7 @@
+joint_layout:
+  left_hip: {x: 0, y: 0}
+  right_hip: {x: 0, y: 1}
+  left_knee: {x: 1, y: 0}
+  right_knee: {x: 1, y: 1}
+  left_ankle: {x: 2, y: 0}
+  right_ankle: {x: 2, y: 1}

--- a/march_rqt_gait_generator/config/layout.yaml
+++ b/march_rqt_gait_generator/config/layout.yaml
@@ -1,7 +1,7 @@
 joint_layout:
-  left_hip: {x: 0, y: 0}
-  right_hip: {x: 0, y: 1}
-  left_knee: {x: 1, y: 0}
-  right_knee: {x: 1, y: 1}
-  left_ankle: {x: 2, y: 0}
-  right_ankle: {x: 2, y: 1}
+  left_hip: {row: 0, column: 0}
+  right_hip: {row: 0, column: 1}
+  left_knee: {row: 1, column: 0}
+  right_knee: {row: 1, column: 1}
+  left_ankle: {row: 2, column: 0}
+  right_ankle: {row: 2, column: 1}

--- a/march_rqt_gait_generator/launch/march_rqt_gait_generator.launch
+++ b/march_rqt_gait_generator/launch/march_rqt_gait_generator.launch
@@ -5,5 +5,7 @@
 
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
 
+    <rosparam file="$(find march_rqt_gait_generator)/config/layout.yaml" command="load"/>
+
     <node name="march_rqt_gait_generator" pkg="march_rqt_gait_generator" type="rqt_gait_generator" output="screen"/>
 </launch>

--- a/march_rqt_gait_generator/resource/gait_generator.ui
+++ b/march_rqt_gait_generator/resource/gait_generator.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>845</width>
+    <width>916</width>
     <height>722</height>
    </rect>
   </property>
@@ -206,34 +206,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="Import">
-        <property name="text">
-         <string>Import Gait</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QPushButton" name="Export">
-        <property name="text">
-         <string>Export Gait</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QLineEdit" name="TopicName">
-        <property name="text">
-         <string>/march/controller/trajectory/full_exoskeleton/command</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QPushButton" name="Publish">
-        <property name="text">
-         <string>Publish</string>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="0">
        <widget class="QPushButton" name="ChangeGaitDirectory">
         <property name="sizePolicy">
@@ -258,6 +230,41 @@ Text-align: right
         </property>
         <property name="text">
          <string>Change Gait Directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="Export">
+        <property name="text">
+         <string>Export Gait</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="4">
+       <widget class="QLineEdit" name="TopicName">
+        <property name="text">
+         <string>/march/controller/trajectory/full_exoskeleton/command</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="4">
+       <widget class="QPushButton" name="Publish">
+        <property name="text">
+         <string>Publish</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="Mirror">
+        <property name="text">
+         <string>Mirror</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QPushButton" name="Import">
+        <property name="text">
+         <string>Import Gait</string>
         </property>
        </widget>
       </item>

--- a/march_rqt_gait_generator/resource/gait_generator.ui
+++ b/march_rqt_gait_generator/resource/gait_generator.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>916</width>
+    <width>941</width>
     <height>722</height>
    </rect>
   </property>
@@ -199,14 +199,55 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="GaitDirectory">
+      <item row="5" column="0" colspan="7">
+       <widget class="QLineEdit" name="TopicName">
         <property name="text">
-         <string>TextLabel</string>
+         <string>/march/controller/trajectory/full_exoskeleton/command</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0" colspan="7">
+       <widget class="QPushButton" name="Publish">
+        <property name="text">
+         <string>Publish</string>
         </property>
        </widget>
       </item>
       <item row="1" column="0">
+       <widget class="QCheckBox" name="Mirror">
+        <property name="text">
+         <string>Mirror</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="Key2">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>left</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLineEdit" name="Key1">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>right</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="4">
+       <widget class="QPushButton" name="Export">
+        <property name="text">
+         <string>Export Gait</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
        <widget class="QPushButton" name="ChangeGaitDirectory">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -233,35 +274,7 @@ Text-align: right
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="QPushButton" name="Export">
-        <property name="text">
-         <string>Export Gait</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="4">
-       <widget class="QLineEdit" name="TopicName">
-        <property name="text">
-         <string>/march/controller/trajectory/full_exoskeleton/command</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="4">
-       <widget class="QPushButton" name="Publish">
-        <property name="text">
-         <string>Publish</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QCheckBox" name="Mirror">
-        <property name="text">
-         <string>Mirror</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="3">
+      <item row="0" column="1" colspan="6">
        <widget class="QPushButton" name="Import">
         <property name="text">
          <string>Import Gait</string>

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -324,11 +324,12 @@ class GaitGeneratorPlugin(Plugin):
         key_2 = self._widget.SettingsFrame.findChild(QLineEdit, "Key2").text()
 
         if should_mirror:
-            mirror = self.gait.get_mirror("left", "right")
+            mirror = self.gait.get_mirror(key_1, key_2)
             if mirror:
                 export_to_file(mirror, self.get_gait_directory())
             else:
                 UserInterfaceController.notify("Could not mirror gait", "Check the logs for more information.")
+                return
 
         export_to_file(self.gait, self.get_gait_directory()),
         self.set_gait_directory_button(self.gait_directory)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -150,9 +150,18 @@ class GaitGeneratorPlugin(Plugin):
             layout.removeWidget(widget)
             widget.setParent(None)
 
-        for i in range(0, len(self.gait.joints)):
-            self._widget.JointSettingContainer.layout().addWidget(self.create_joint_setting(self.gait.joints[i]), i % 3,
-                                                                  i >= 3)
+        for i in range(0, len(self.robot.joints)):
+
+            if self.robot.joints[i].type != "fixed":
+                joint_name = self.robot.joints[i].name
+                joint = self.gait.get_joint(joint_name)
+                print joint_name, joint
+
+                x = rospy.get_param("/joint_layout/" + joint_name + "/x", -1)
+                y = rospy.get_param("/joint_layout/" + joint_name + "/y", -1)
+                if x == -1 or y == -1:
+                    rospy.logerr("Could not load the layout for joint %s. Please check config/layout.yaml", joint_name)
+                self._widget.JointSettingContainer.layout().addWidget(self.create_joint_setting(joint), x, y)
 
     def create_joint_setting(self, joint):
         joint_setting_file = os.path.join(rospkg.RosPack().get_path('march_rqt_gait_generator'), 'resource',

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -155,7 +155,6 @@ class GaitGeneratorPlugin(Plugin):
             if self.robot.joints[i].type != "fixed":
                 joint_name = self.robot.joints[i].name
                 joint = self.gait.get_joint(joint_name)
-                print joint_name, joint
 
                 x = rospy.get_param("/joint_layout/" + joint_name + "/x", -1)
                 y = rospy.get_param("/joint_layout/" + joint_name + "/y", -1)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -158,12 +158,12 @@ class GaitGeneratorPlugin(Plugin):
                 joint_name = self.robot.joints[i].name
                 joint = self.gait.get_joint(joint_name)
 
-                x = rospy.get_param("/joint_layout/" + joint_name + "/x", -1)
-                y = rospy.get_param("/joint_layout/" + joint_name + "/y", -1)
-                if x == -1 or y == -1:
+                row = rospy.get_param("/joint_layout/" + joint_name + "/row", -1)
+                column = rospy.get_param("/joint_layout/" + joint_name + "/column", -1)
+                if row == -1 or column == -1:
                     rospy.logerr("Could not load the layout for joint %s. Please check config/layout.yaml", joint_name)
                     continue
-                self._widget.JointSettingContainer.layout().addWidget(self.create_joint_setting(joint), x, y)
+                self._widget.JointSettingContainer.layout().addWidget(self.create_joint_setting(joint), row, column)
 
     def create_joint_setting(self, joint):
         joint_setting_file = os.path.join(rospkg.RosPack().get_path('march_rqt_gait_generator'), 'resource',

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -160,6 +160,7 @@ class GaitGeneratorPlugin(Plugin):
                 y = rospy.get_param("/joint_layout/" + joint_name + "/y", -1)
                 if x == -1 or y == -1:
                     rospy.logerr("Could not load the layout for joint %s. Please check config/layout.yaml", joint_name)
+                    continue
                 self._widget.JointSettingContainer.layout().addWidget(self.create_joint_setting(joint), x, y)
 
     def create_joint_setting(self, joint):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -75,6 +75,7 @@ class GaitGeneratorPlugin(Plugin):
         self._widget.SettingsFrame.findChild(QPushButton, "Export").clicked.connect(
             lambda: [
                 export_to_file(self.gait, self.get_gait_directory()),
+                export_to_file(self.gait.get_mirrored("left", "right"), self.get_gait_directory()),
                 self.set_gait_directory_button(self.gait_directory)
             ]
         )

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -340,8 +340,13 @@ class GaitGeneratorPlugin(Plugin):
         self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait").setText(self.gait.subgait)
         self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version").setText(self.gait.version)
         self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description").setText(self.gait.description)
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setValue(self.gait.duration)
 
+        # Block signals on the duration edit to prevent a reload of the joint settings
+        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").blockSignals(True)
+        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setValue(self.gait.duration)
+        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").blockSignals(False)
+
+        print ('load gait into ui')
         self.create_joint_settings()
 
         self.publish_preview()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -140,10 +140,12 @@ class Gait:
                 rospy.loginfo("Should not happen")
                 return False
 
-            if joint_1.setpoints[0].position != joint_2.setpoints[-1].position or joint_1.setpoints[0].velocity != joint_2.setpoints[-1].velocity:
+            if joint_1.setpoints[0].position != joint_2.setpoints[-1].position \
+                    or joint_1.setpoints[0].velocity != joint_2.setpoints[-1].velocity:
                 rospy.loginfo("First setpoint of %s != last setpoint of %s", joint_1.name, joint_2.name)
                 return False
-            if joint_1.setpoints[-1].position != joint_2.setpoints[0].position or joint_1.setpoints[-1].velocity != joint_2.setpoints[0].velocity:
+            if joint_1.setpoints[-1].position != joint_2.setpoints[0].position \
+                    or joint_1.setpoints[-1].velocity != joint_2.setpoints[0].velocity:
                 rospy.loginfo("Last setpoint of %s != first setpoint of %s", joint_1.name, joint_2.name)
                 return False
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -138,7 +138,10 @@ class Gait:
                 joint_1 = self.get_joint(joint.name.replace(key_2, key_1))
                 joint_2 = joint
             else:
-                rospy.loginfo("Should not happen")
+                continue
+
+            if joint_1 is None or joint_2 is None:
+                rospy.logwarn("Joints %s and %s are not valid.", str(joint_1), str(joint_2))
                 return False
 
             if joint_1.setpoints[0].position != joint_2.setpoints[-1].position \

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -2,7 +2,10 @@ import rospy
 from trajectory_msgs.msg import JointTrajectory
 from trajectory_msgs.msg import JointTrajectoryPoint
 
+from Joint import Joint
+
 from march_shared_resources.msg import Setpoint
+from march_rqt_gait_generator.UserInterfaceController import notify
 
 
 class Gait:
@@ -112,3 +115,20 @@ class Gait:
 
     def set_current_time(self, current_time):
         self.current_time = current_time
+
+    def get_mirrored(self, from_key, to_key):
+        if from_key not in self.subgait:
+            notify("Could not mirror Subgait.",
+                   "Subgait name " + self.subgait + " does not contain required key " + from_key)
+            return False
+
+        mirrored_subgait_name = self.subgait.replace(from_key, to_key)
+
+        mirrored_joints = []
+        for joint in self.joints:
+            mirrored_name = joint.name.replace(from_key, to_key)
+            mirrored_joint = Joint(mirrored_name, joint.limits, joint.setpoints, joint.duration)
+            mirrored_joints.append(mirrored_joint)
+
+        return Gait(mirrored_joints, self.duration, self.name, mirrored_subgait_name, self.version, self.description)
+

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -120,8 +120,9 @@ class Gait:
         if not key_1 or not key_2:
             rospy.loginfo("Keys are invalid")
             return False
+
         # XNOR, only one key can and must exist in the subgait name
-        if key_1 in self.subgait == key_2 in self.subgait:
+        if (key_1 in self.subgait) == (key_2 in self.subgait):
             rospy.loginfo("Multiple or no keys exist in subgait %s", self.subgait)
             return False
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -116,17 +116,25 @@ class Gait:
     def set_current_time(self, current_time):
         self.current_time = current_time
 
-    def get_mirrored(self, from_key, to_key):
-        if from_key not in self.subgait:
+    def get_mirrored(self, key_1, key_2):
+        if key_1 in self.subgait:
+            mirrored_subgait_name = self.subgait.replace(key_1, key_2)
+        elif key_2 in self.subgait:
+            mirrored_subgait_name = self.subgait.replace(key_2, key_1)
+        else:
             notify("Could not mirror Subgait.",
-                   "Subgait name " + self.subgait + " does not contain required key " + from_key)
+                   "Subgait name " + self.subgait + " does not contain required key " + key_1)
             return False
-
-        mirrored_subgait_name = self.subgait.replace(from_key, to_key)
 
         mirrored_joints = []
         for joint in self.joints:
-            mirrored_name = joint.name.replace(from_key, to_key)
+            if key_1 in joint.name:
+                mirrored_name = joint.name.replace(key_1, key_2)
+            elif key_2 in joint.name:
+                mirrored_name = joint.name.replace(key_2, key_1)
+            else:
+                continue
+
             mirrored_joint = Joint(mirrored_name, joint.limits, joint.setpoints, joint.duration)
             mirrored_joints.append(mirrored_joint)
 


### PR DESCRIPTION
Add gait mirroring, when it's enabled the current gait is saved as 2 gaits. The user enters 2 keys, for example 'left' and 'right'. 2 subgaits are created, one with the normal name and one with key 1 replaced with key 2 (or the other way around). Then for the name of each joint, the key is swapped as well.

## Features
- Add custom layout, in the `config/layout.yaml` you can determine which joint editor should go where.
- Fix a bug where the jointsettings would load twice (might fix #19)
- Allow custom keys to be set from the ui
