### PR TITLE
Fix joint duration not updating

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/Gait.py
@@ -108,6 +108,8 @@ class Gait:
                         joint.setpoints.remove(setpoint)
             joint.interpolated_setpoints = joint.interpolate_setpoints()
 
+            joint.duration = duration
+
         self.duration = duration
 
     def set_current_time(self, current_time):


### PR DESCRIPTION
Closes #4 

Turns out to be a simple fix, only the gait duration was updated, and not the duration of the joint. This would cause them not to interpolate after the old duration.

There is still the issue that the preview doesn't work after the latest setpoint, but that is another issue