### PR TITLE
Store qt objects in gait generator memory to only retrieve them once

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -61,6 +61,7 @@ class GaitGeneratorPlugin(Plugin):
         # Store ui elements.
         self.change_gait_directory_button = self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory")
         self.import_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Import")
+        self.export_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Export")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -76,7 +77,7 @@ class GaitGeneratorPlugin(Plugin):
             ]
         )
 
-        self._widget.SettingsFrame.findChild(QPushButton, "Export").clicked.connect(self.export)
+        self.export_gait_button.clicked.connect(self.export)
 
         self._widget.SettingsFrame.findChild(QPushButton, "Publish").clicked.connect(
             lambda: self.publish_gait()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -77,6 +77,7 @@ class GaitGeneratorPlugin(Plugin):
         self.mirror_key2_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key2")
         self.velocity_markers_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers")
         self.time_slider = self._widget.RvizFrame.findChild(QSlider, "TimeSlider")
+        self.scale_setpoints_check_box = self._widget.GaitPropertiesFrame.findChild(QCheckBox, "ScaleSetpoints")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -325,7 +326,7 @@ class GaitGeneratorPlugin(Plugin):
         self.time_slider_thread.start()
 
     def update_gait_duration(self, duration):
-        rescale_setpoints = self._widget.GaitPropertiesFrame.findChild(QCheckBox, "ScaleSetpoints").isChecked()
+        rescale_setpoints = self.scale_setpoints_check_box.isChecked()
 
         if self.gait.has_setpoints_after_duration(duration) and not rescale_setpoints:
             if not self.gait.has_multiple_setpoints_before_duration(duration):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -75,6 +75,7 @@ class GaitGeneratorPlugin(Plugin):
         self.mirror_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "Mirror")
         self.mirror_key1_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key1")
         self.mirror_key2_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key2")
+        self.velocity_markers_check_box = self.velocity_markers_check_box
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -149,7 +150,7 @@ class GaitGeneratorPlugin(Plugin):
         self.load_gait_into_ui()
 
     def toggle_velocity_markers(self):
-        self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers").toggle()
+        self.velocity_markers_check_box.toggle()
 
     def create_rviz_frame(self):
         frame = rviz.VisualizationFrame()
@@ -194,10 +195,10 @@ class GaitGeneratorPlugin(Plugin):
         joint_setting = QFrame()
         loadUi(joint_setting_file, joint_setting)
 
-        show_velocity_markers = self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers").isChecked()
+        show_velocity_markers = self.velocity_markers_check_box.isChecked()
         joint_setting_plot = JointSettingPlot(joint, self.gait.duration, show_velocity_markers)
 
-        self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers").stateChanged.connect(
+        self.velocity_markers_check_box.stateChanged.connect(
             lambda: [joint.set_setpoints(UserInterfaceController.plot_to_setpoints(joint_setting_plot)),
                      UserInterfaceController.update_ui_elements(
                          joint, table=joint_setting.Table, plot=joint_setting_plot, duration=self.gait.duration,
@@ -254,7 +255,7 @@ class GaitGeneratorPlugin(Plugin):
         return joint_setting
 
     def show_velocity_markers_checked(self):
-        return self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers").isChecked()
+        return self.velocity_markers_check_box.isChecked()
 
     def add_setpoint(self, joint, time, position, button):
         if button == QtCore.Qt.ControlModifier:

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -72,6 +72,7 @@ class GaitGeneratorPlugin(Plugin):
         self.subgait_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait")
         self.description_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description")
         self.duration_spin_box = self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration")
+        self.mirror_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "Mirror")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -133,7 +134,7 @@ class GaitGeneratorPlugin(Plugin):
         )
 
         # Disable key inputs when mirroring is off.
-        self._widget.SettingsFrame.findChild(QCheckBox, "Mirror").stateChanged.connect(
+        self.mirror_check_box.stateChanged.connect(
             lambda state: [
                 self._widget.SettingsFrame.findChild(QLineEdit, "Key1").setEnabled(state),
                 self._widget.SettingsFrame.findChild(QLineEdit, "Key2").setEnabled(state)
@@ -354,7 +355,7 @@ class GaitGeneratorPlugin(Plugin):
             self.time_slider_thread = None
 
     def export(self):
-        should_mirror = self._widget.SettingsFrame.findChild(QCheckBox, "Mirror").isChecked()
+        should_mirror = self.mirror_check_box.isChecked()
 
         key_1 = self._widget.SettingsFrame.findChild(QLineEdit, "Key1").text()
         key_2 = self._widget.SettingsFrame.findChild(QLineEdit, "Key2").text()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -65,6 +65,7 @@ class GaitGeneratorPlugin(Plugin):
         self.publish_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Publish")
         self.start_button = self._widget.RvizFrame.findChild(QPushButton, "Start")
         self.stop_button = self._widget.RvizFrame.findChild(QPushButton, "Stop")
+        self.playback_speed_line_edit = self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -90,10 +91,10 @@ class GaitGeneratorPlugin(Plugin):
 
         self.stop_button.clicked.connect(self.stop_time_slider_thread)
 
-        self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed").setValidator(QtGui.QIntValidator(0, 500, self))
-        self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed").editingFinished.connect(
+        self.playback_speed_line_edit.setValidator(QtGui.QIntValidator(0, 500, self))
+        self.playback_speed_line_edit.editingFinished.connect(
             lambda: [
-                self.set_playback_speed(float(self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed").text())),
+                self.set_playback_speed(float(self.playback_speed_line_edit.text())),
                 rospy.loginfo("Changing playbackspeed to " + str(self.playback_speed)),
             ]
         )

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -58,9 +58,13 @@ class GaitGeneratorPlugin(Plugin):
         self.rviz_frame = self.create_rviz_frame()
         self._widget.RvizFrame.layout().addWidget(self.rviz_frame, 1, 0, 1, 3)
 
+        # Store ui elements.
+        self.change_gait_directory_button = self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory")
+
+
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
-        self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory").clicked.connect(
+        self.change_gait_directory_button.clicked.connect(
             lambda: [
                 self.set_gait_directory_button(self.get_gait_directory(True))
             ]
@@ -255,7 +259,7 @@ class GaitGeneratorPlugin(Plugin):
     def set_gait_directory_button(self, gait_directory):
         if gait_directory is None:
             gait_directory = "Select a gait directory..."
-        self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory").setText(gait_directory)
+        self.change_gait_directory_button.setText(gait_directory)
 
     def publish_preview(self):
         joint_state = JointState()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -71,6 +71,7 @@ class GaitGeneratorPlugin(Plugin):
         self.version_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version")
         self.subgait_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait")
         self.description_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description")
+        self.duration_spin_box = self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -125,10 +126,10 @@ class GaitGeneratorPlugin(Plugin):
                 self.description_line_edit.text())
         )
 
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setKeyboardTracking(False)
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").valueChanged.connect(
+        self.duration_spin_box.setKeyboardTracking(False)
+        self.duration_spin_box.valueChanged.connect(
             lambda: self.update_gait_duration(
-                self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").value())
+                self.duration_spin_box.value())
         )
 
         # Disable key inputs when mirroring is off.
@@ -334,7 +335,7 @@ class GaitGeneratorPlugin(Plugin):
                                                      "duration?",
                                                      QMessageBox.Yes | QMessageBox.No)
             if discard_setpoints == QMessageBox.No:
-                self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setValue(self.gait.duration)
+                self.duration_spin_box.setValue(self.gait.duration)
                 return
         self.gait.set_duration(duration, rescale_setpoints)
         self._widget.RvizFrame.findChild(QSlider, "TimeSlider").setRange(0, 100 * self.gait.duration)
@@ -411,9 +412,9 @@ class GaitGeneratorPlugin(Plugin):
         self.description_line_edit.setText(self.gait.description)
 
         # Block signals on the duration edit to prevent a reload of the joint settings
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").blockSignals(True)
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setValue(self.gait.duration)
-        self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").blockSignals(False)
+        self.duration_spin_box.blockSignals(True)
+        self.duration_spin_box.setValue(self.gait.duration)
+        self.duration_spin_box.blockSignals(False)
 
         print ('load gait into ui')
         self.create_joint_settings()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -393,10 +393,11 @@ class GaitGeneratorPlugin(Plugin):
             self.gait_directory = gait_directory
             self.set_gait_directory_button(gait_directory)
 
-        self.gait = import_from_file_name(self.robot, file_name)
-        if self.gait is None:
+        gait = import_from_file_name(self.robot, file_name)
+        if gait is None:
             rospy.logwarn("Could not load gait %s", file_name)
         else:
+            self.gait = gait
             self.load_gait_into_ui()
 
     def load_gait_into_ui(self):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -75,7 +75,7 @@ class GaitGeneratorPlugin(Plugin):
         self.mirror_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "Mirror")
         self.mirror_key1_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key1")
         self.mirror_key2_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key2")
-        self.velocity_markers_check_box = self.velocity_markers_check_box
+        self.velocity_markers_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "ShowVelocityMarkers")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -62,6 +62,7 @@ class GaitGeneratorPlugin(Plugin):
         self.change_gait_directory_button = self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory")
         self.import_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Import")
         self.export_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Export")
+        self.publish_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Publish")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -79,7 +80,7 @@ class GaitGeneratorPlugin(Plugin):
 
         self.export_gait_button.clicked.connect(self.export)
 
-        self._widget.SettingsFrame.findChild(QPushButton, "Publish").clicked.connect(
+        self.publish_gait_button.clicked.connect(
             lambda: self.publish_gait()
         )
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -63,6 +63,8 @@ class GaitGeneratorPlugin(Plugin):
         self.import_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Import")
         self.export_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Export")
         self.publish_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Publish")
+        self.start_button = self._widget.RvizFrame.findChild(QPushButton, "Start")
+        self.stop_button = self._widget.RvizFrame.findChild(QPushButton, "Stop")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -84,9 +86,9 @@ class GaitGeneratorPlugin(Plugin):
             lambda: self.publish_gait()
         )
 
-        self._widget.RvizFrame.findChild(QPushButton, "Start").clicked.connect(self.start_time_slider_thread)
+        self.start_button.clicked.connect(self.start_time_slider_thread)
 
-        self._widget.RvizFrame.findChild(QPushButton, "Stop").clicked.connect(self.stop_time_slider_thread)
+        self.stop_button.clicked.connect(self.stop_time_slider_thread)
 
         self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed").setValidator(QtGui.QIntValidator(0, 500, self))
         self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed").editingFinished.connect(

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -66,6 +66,7 @@ class GaitGeneratorPlugin(Plugin):
         self.start_button = self._widget.RvizFrame.findChild(QPushButton, "Start")
         self.stop_button = self._widget.RvizFrame.findChild(QPushButton, "Stop")
         self.playback_speed_line_edit = self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed")
+        self.topic_name_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "TopicName")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -99,8 +100,8 @@ class GaitGeneratorPlugin(Plugin):
             ]
         )
 
-        self._widget.SettingsFrame.findChild(QLineEdit, "TopicName").editingFinished.connect(
-            lambda: self.set_topic_name(self._widget.SettingsFrame.findChild(QLineEdit, "TopicName").text())
+        self.topic_name_line_edit.editingFinished.connect(
+            lambda: self.set_topic_name(self.topic_name_line_edit.text())
         )
 
         self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Gait").editingFinished.connect(
@@ -135,7 +136,7 @@ class GaitGeneratorPlugin(Plugin):
         )
 
         # Initialize the publisher on startup
-        self.set_topic_name(self._widget.SettingsFrame.findChild(QLineEdit, "TopicName").text())
+        self.set_topic_name(self.topic_name_line_edit.text())
 
         self.load_gait_into_ui()
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -60,7 +60,7 @@ class GaitGeneratorPlugin(Plugin):
 
         # Store ui elements.
         self.change_gait_directory_button = self._widget.SettingsFrame.findChild(QPushButton, "ChangeGaitDirectory")
-
+        self.import_gait_button = self._widget.SettingsFrame.findChild(QPushButton, "Import")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -70,7 +70,7 @@ class GaitGeneratorPlugin(Plugin):
             ]
         )
 
-        self._widget.SettingsFrame.findChild(QPushButton, "Import").clicked.connect(
+        self.import_gait_button.clicked.connect(
             lambda: [
                 self.load_gait()
             ]

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -67,6 +67,10 @@ class GaitGeneratorPlugin(Plugin):
         self.stop_button = self._widget.RvizFrame.findChild(QPushButton, "Stop")
         self.playback_speed_line_edit = self._widget.RvizFrame.findChild(QLineEdit, "PlaybackSpeed")
         self.topic_name_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "TopicName")
+        self.gait_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Gait")
+        self.version_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version")
+        self.subgait_name_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait")
+        self.description_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -104,21 +108,21 @@ class GaitGeneratorPlugin(Plugin):
             lambda: self.set_topic_name(self.topic_name_line_edit.text())
         )
 
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Gait").editingFinished.connect(
-            lambda: self.gait.set_name(self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Gait").text())
+        self.gait_name_line_edit.editingFinished.connect(
+            lambda: self.gait.set_name(self.gait_name_line_edit.text())
         )
 
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version").editingFinished.connect(
-            lambda: self.gait.set_version(self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version").text())
+        self.version_name_line_edit.editingFinished.connect(
+            lambda: self.gait.set_version(self.version_name_line_edit.text())
         )
 
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait").editingFinished.connect(
-            lambda: self.gait.set_subgait(self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait").text())
+        self.subgait_name_line_edit.editingFinished.connect(
+            lambda: self.gait.set_subgait(self.subgait_name_line_edit.text())
         )
 
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description").editingFinished.connect(
+        self.description_line_edit.editingFinished.connect(
             lambda: self.gait.set_description(
-                self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description").text())
+                self.description_line_edit.text())
         )
 
         self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").setKeyboardTracking(False)
@@ -401,10 +405,10 @@ class GaitGeneratorPlugin(Plugin):
             self.update_time_sliders(),
         ])
 
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Gait").setText(self.gait.name)
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Subgait").setText(self.gait.subgait)
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Version").setText(self.gait.version)
-        self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description").setText(self.gait.description)
+        self.gait_name_line_edit.setText(self.gait.name)
+        self.subgait_name_line_edit.setText(self.gait.subgait)
+        self.version_name_line_edit.setText(self.gait.version)
+        self.description_line_edit.setText(self.gait.description)
 
         # Block signals on the duration edit to prevent a reload of the joint settings
         self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration").blockSignals(True)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator.py
@@ -73,6 +73,8 @@ class GaitGeneratorPlugin(Plugin):
         self.description_line_edit = self._widget.GaitPropertiesFrame.findChild(QLineEdit, "Description")
         self.duration_spin_box = self._widget.GaitPropertiesFrame.findChild(QDoubleSpinBox, "Duration")
         self.mirror_check_box = self._widget.SettingsFrame.findChild(QCheckBox, "Mirror")
+        self.mirror_key1_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key1")
+        self.mirror_key2_line_edit = self._widget.SettingsFrame.findChild(QLineEdit, "Key2")
 
         # Connect Gait settings buttons
         self.set_gait_directory_button(self.gait_directory)
@@ -136,8 +138,8 @@ class GaitGeneratorPlugin(Plugin):
         # Disable key inputs when mirroring is off.
         self.mirror_check_box.stateChanged.connect(
             lambda state: [
-                self._widget.SettingsFrame.findChild(QLineEdit, "Key1").setEnabled(state),
-                self._widget.SettingsFrame.findChild(QLineEdit, "Key2").setEnabled(state)
+                self.mirror_key1_line_edit.setEnabled(state),
+                self.mirror_key2_line_edit.setEnabled(state)
             ]
         )
 
@@ -357,8 +359,8 @@ class GaitGeneratorPlugin(Plugin):
     def export(self):
         should_mirror = self.mirror_check_box.isChecked()
 
-        key_1 = self._widget.SettingsFrame.findChild(QLineEdit, "Key1").text()
-        key_2 = self._widget.SettingsFrame.findChild(QLineEdit, "Key2").text()
+        key_1 = self.mirror_key1_line_edit.text()
+        key_2 = self.mirror_key2_line_edit.text()
 
         if should_mirror:
             mirror = self.gait.get_mirror(key_1, key_2)


### PR DESCRIPTION
This refactor should not change functionality at all, and is mainly to avoid redundancy in the retrieving of UI elements. They are now stored in the memory of the plugin and can be easily accessed.

I'm planning to do the same for the JointSetting frame as redrawing that ui is kind of a mess at the moment. 

Many small commits to easily check which commit would break if that's the case.

To the reviewers, please check if all functionality is still the same. (import/export, publish, time slider, preview)