### PR TITLE
Fix: convert unicode string from UI to string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - ROS_REPO=ros
     - BUILDER=colcon
     - CATKIN_LINT=pedantic
-    - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gain_scheduling -march/march_gait_scheduler -march/march_gait_selection -march/march_launch -march/march_safety -march/march_sound_scheduler -march/march_state_machine'
+    - UPSTREAM_WORKSPACE='.rosinstall -march/march_data_collector -march/march_gain_scheduling -march/march_gait_scheduler -march/march_gait_selection -march/march_launch -march/march_safety -march/march_state_machine'
 
 jobs:
   include:

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -137,16 +137,16 @@ class ModifiableSubgait(Subgait):
         self.gait_type = str(gait_type)
 
     def set_gait_name(self, gait_name):
-        self.gait_name = gait_name
+        self.gait_name = str(gait_name)
 
     def set_description(self, description):
         self.description = str(description)
 
     def set_version(self, version):
-        self.version = version
+        self.version = str(version)
 
     def set_subgait_name(self, subgait_name):
-        self.subgait_name = subgait_name
+        self.subgait_name = str(subgait_name)
 
     def set_duration(self, duration, rescale=False):
         for joint in self.joints:


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-258

## Description
Strings from the Qt UI are of `unicode` type which were not casted to a `str` everywhere. That is why the `description` worked and `subgait_name` did not.

## Changes
* Convert to `str`

<!-- Please don't forget to request for reviews -->
