### PR TITLE
Enable mirroring when gaits do not fully match

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -100,12 +100,12 @@ class ModifiableSubgait(Subgait):
 
             if joint_1.setpoints[0].position != joint_2.setpoints[-1].position \
                     or joint_1.setpoints[0].velocity != joint_2.setpoints[-1].velocity:
-                rospy.loginfo('First setpoint of %s != last setpoint of %s', joint_1.name, joint_2.name)
-                return False
+                rospy.loginfo('First setpoint of %s != last setpoint of %s. These subgaits will not be able to loop.',
+                              joint_1.name, joint_2.name)
             if joint_1.setpoints[-1].position != joint_2.setpoints[0].position \
                     or joint_1.setpoints[-1].velocity != joint_2.setpoints[0].velocity:
-                rospy.loginfo('Last setpoint of %s != first setpoint of %s', joint_1.name, joint_2.name)
-                return False
+                rospy.loginfo('Last setpoint of %s != first setpoint of %s. These subgaits will not be able to loop.',
+                              joint_1.name, joint_2.name)
 
         return True
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

Movement requested enabling mirror when the endpoints of the left joint do not match the start point of the right joint (and vice versa). This feature was initially meant to enforce correct transitions in, for example, a left_swing and right_swing. Mirror be used more diversely though.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Enable mirror when transitions are not correct
* Change info message when this happens

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
