### PR TITLE
Feature: lock start end setpoint

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -42,13 +42,15 @@ class GaitGeneratorController(object):
         self.view.import_gait_button.clicked.connect(self.import_gait)
         self.view.export_gait_button.clicked.connect(self.export_gait)
 
-        self.view.side_subgait_view['previous'].import_button.clicked.connect(lambda: self.import_side_subgait('previous'))
+        self.view.side_subgait_view['previous'].import_button.clicked.connect(
+            lambda: self.import_side_subgait('previous'))
         self.view.side_subgait_view['previous'].default_checkbox.stateChanged.connect(
             lambda value: self.toggle_side_subgait_checkbox(value, 'previous', 'standing'))
         self.view.side_subgait_view['previous'].lock_checkbox.stateChanged.connect(
             lambda value: self.toggle_side_subgait_checkbox(value, 'previous', 'lock'))
 
-        self.view.side_subgait_view['next'].import_button.clicked.connect(lambda: self.import_side_subgait('next'))
+        self.view.side_subgait_view['next'].import_button.clicked.connect(
+            lambda: self.import_side_subgait('next'))
         self.view.side_subgait_view['next'].default_checkbox.stateChanged.connect(
             lambda value: self.toggle_side_subgait_checkbox(value, 'next', 'standing'))
         self.view.side_subgait_view['next'].lock_checkbox.stateChanged.connect(

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -309,10 +309,15 @@ class GaitGeneratorController(object):
             self.view.change_gait_directory_button.setText(self.gait_directory)
 
     def invert_gait(self):
+        for side, controller in self.side_subgait_controller.items():
+            controller.lock_checked = False
+            self.handle_sidepoint_lock(side)
+
         for joint in self.subgait.joints:
             joint.invert()
             self.view.update_joint_widget(joint)
-        self.save_changed_settings({'joints': [self.subgait.joints]})
+        self.save_changed_settings({'joints': self.subgait.joints,
+                                    'side_subgaits': self.side_subgait_controller.values()})
         self.view.publish_preview(self.subgait, self.current_time)
 
     def undo(self):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -389,6 +389,12 @@ class GaitGeneratorController(object):
                     joint.start_point = side_subgait_joint.setpoints[-1]
                 elif side == 'next':
                     joint.end_point = side_subgait_joint.setpoints[0]
+        elif self.side_subgait_controller[side].subgait is None:
+            for joint in self.subgait.joints:
+                if side == 'previous':
+                    joint.start_point = joint.setpoints[0]
+                elif side == 'next':
+                    joint.end_point = joint.setpoints[-1]
 
         else:
             for joint in self.subgait.joints:

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -42,12 +42,17 @@ class GaitGeneratorController(object):
         self.view.import_gait_button.clicked.connect(self.import_gait)
         self.view.export_gait_button.clicked.connect(self.export_gait)
 
-        for side in self.side_subgait_controller.keys():
-            self.view.side_subgait_view[side].import_button.clicked.connect(lambda: self.import_side_subgait(side))
-            self.view.side_subgait_view[side].default_checkbox.stateChanged.connect(
-                lambda value: self.toggle_side_subgait_checkbox(value, side, 'standing'))
-            self.view.side_subgait_view[side].lock_checkbox.stateChanged.connect(
-                lambda value: self.toggle_side_subgait_checkbox(value, side, 'lock'))
+        self.view.side_subgait_view['previous'].import_button.clicked.connect(lambda: self.import_side_subgait('previous'))
+        self.view.side_subgait_view['previous'].default_checkbox.stateChanged.connect(
+            lambda value: self.toggle_side_subgait_checkbox(value, 'previous', 'standing'))
+        self.view.side_subgait_view['previous'].lock_checkbox.stateChanged.connect(
+            lambda value: self.toggle_side_subgait_checkbox(value, 'previous', 'lock'))
+
+        self.view.side_subgait_view['next'].import_button.clicked.connect(lambda: self.import_side_subgait('next'))
+        self.view.side_subgait_view['next'].default_checkbox.stateChanged.connect(
+            lambda value: self.toggle_side_subgait_checkbox(value, 'next', 'standing'))
+        self.view.side_subgait_view['next'].lock_checkbox.stateChanged.connect(
+            lambda value: self.toggle_side_subgait_checkbox(value, 'next', 'lock'))
 
         self.view.start_button.clicked.connect(self.start_time_slider_thread)
         self.view.stop_button.clicked.connect(self.stop_time_slider_thread)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -382,20 +382,20 @@ class GaitGeneratorController(object):
         self.handle_sidepoint_lock(side)
 
     def handle_sidepoint_lock(self, side):
-        if self.side_subgait_controller[side].lock_checked and self.side_subgait_controller[side].subgait is not None:
-            for joint, side_subgait_joint in zip(self.subgait.joints,
-                                                 self.side_subgait_controller[side].subgait.joints):
-                if side == 'previous':
-                    joint.start_point = side_subgait_joint.setpoints[-1]
-                elif side == 'next':
-                    joint.end_point = side_subgait_joint.setpoints[0]
-        elif self.side_subgait_controller[side].subgait is None:
-            for joint in self.subgait.joints:
-                if side == 'previous':
-                    joint.start_point = joint.setpoints[0]
-                elif side == 'next':
-                    joint.end_point = joint.setpoints[-1]
-
+        if self.side_subgait_controller[side].lock_checked:
+            if self.side_subgait_controller[side].subgait is not None:
+                for joint, side_subgait_joint in zip(self.subgait.joints,
+                                                     self.side_subgait_controller[side].subgait.joints):
+                    if side == 'previous':
+                        joint.start_point = side_subgait_joint.setpoints[-1]
+                    elif side == 'next':
+                        joint.end_point = side_subgait_joint.setpoints[0]
+            else:
+                for joint in self.subgait.joints:
+                    if side == 'previous':
+                        joint.start_point = joint.setpoints[0]
+                    elif side == 'next':
+                        joint.end_point = joint.setpoints[-1]
         else:
             for joint in self.subgait.joints:
                 if side == 'previous':

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -4,9 +4,9 @@ from numpy_ringbuffer import RingBuffer
 import rospy
 
 from .model.modifiable_setpoint import ModifiableSetpoint
+from .model.modifiable_subgait import ModifiableSubgait
 from .side_subgait_controller import SideSubgaitController
 from .side_subgait_view import SideSubgaitView
-from .model.modifiable_subgait import ModifiableSubgait
 
 
 class GaitGeneratorController(object):
@@ -322,14 +322,14 @@ class GaitGeneratorController(object):
 
         changed_dict = self.settings_changed_history.pop()
 
-        if changed_dict.has_key('joints'):
+        if 'joints' in changed_dict:
             joints = changed_dict['joints']
             for joint in joints:
                 joint.undo()
             self.subgait.set_duration(joints[0].setpoints[-1].time)
             self.view.set_duration_spinbox(self.subgait.duration)
 
-        if changed_dict.has_key('side_subgaits'):
+        if 'side_subgaits' in changed_dict:
             side_subgait_controllers = changed_dict['side_subgaits']
             for controller in side_subgait_controllers:
                 controller.undo()
@@ -344,14 +344,14 @@ class GaitGeneratorController(object):
 
         changed_dict = self.settings_changed_redo_list.pop()
 
-        if changed_dict.has_key('joints'):
+        if 'joints' in changed_dict:
             joints = changed_dict['joints']
             for joint in joints:
                 joint.redo()
             self.subgait.set_duration(joints[0].setpoints[-1].time)
             self.view.set_duration_spinbox(self.subgait.duration)
 
-        if changed_dict.has_key('side_subgaits'):
+        if 'side_subgaits' in changed_dict:
             side_subgait_controllers = changed_dict['side_subgaits']
             for controller in side_subgait_controllers:
                 controller.redo()
@@ -366,13 +366,13 @@ class GaitGeneratorController(object):
         self.settings_changed_redo_list = RingBuffer(capacity=100, dtype=list)
 
     # Functions related to previous/next subgait
-    def toggle_side_subgait_checkbox(self, value, side_subgait_controller, side, type):
+    def toggle_side_subgait_checkbox(self, value, side_subgait_controller, side, box_type):
         self.save_changed_settings({'joints': self.subgait.joints, 'side_subgaits': [side_subgait_controller]})
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
-        if type == 'lock':
+        if box_type == 'lock':
             side_subgait_controller.lock_checked = value
-        elif type == 'standing':
+        elif box_type == 'standing':
             side_subgait_controller.default_checked = value
         self.handle_sidepoint_lock(side_subgait_controller, side)
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -6,7 +6,6 @@ import rospy
 from .model.modifiable_setpoint import ModifiableSetpoint
 from .model.modifiable_subgait import ModifiableSubgait
 from .side_subgait_controller import SideSubgaitController
-from .side_subgait_view import SideSubgaitView
 
 
 class GaitGeneratorController(object):
@@ -26,11 +25,11 @@ class GaitGeneratorController(object):
         self.settings_changed_history = RingBuffer(capacity=100, dtype=list)
         self.settings_changed_redo_list = RingBuffer(capacity=100, dtype=list)
 
-        self.previous_subgait_view = SideSubgaitView(widget=self.view.previous_subgait_container)
-        self.next_subgait_view = SideSubgaitView(widget=self.view.next_subgait_container)
         standing = ModifiableSubgait.empty_subgait(self, self.robot)
-        self.previous_subgait_controller = SideSubgaitController(view=self.previous_subgait_view, default=standing)
-        self.next_subgait_controller = SideSubgaitController(view=self.next_subgait_view, default=standing)
+        previous_subgait_controller = SideSubgaitController(view=self.view.side_subgait_view['previous'],
+                                                            default=standing)
+        next_subgait_controller = SideSubgaitController(view=self.view.side_subgait_view['next'], default=standing)
+        self.side_subgait_controller = {'previous': previous_subgait_controller, 'next': next_subgait_controller}
 
         self.connect_buttons()
         self.view.load_gait_into_ui(self.subgait)
@@ -43,19 +42,12 @@ class GaitGeneratorController(object):
         self.view.import_gait_button.clicked.connect(self.import_gait)
         self.view.export_gait_button.clicked.connect(self.export_gait)
 
-        self.previous_subgait_view.import_button.clicked.connect(lambda: self.import_side_subgait('previous'))
-        self.previous_subgait_view.default_checkbox.stateChanged.connect(
-            lambda value: self.toggle_side_subgait_checkbox(value, self.previous_subgait_controller, 'previous',
-                                                            'standing'))
-        self.previous_subgait_view.lock_checkbox.stateChanged.connect(
-            lambda value: self.toggle_side_subgait_checkbox(value, self.previous_subgait_controller, 'previous',
-                                                            'lock'))
-
-        self.next_subgait_view.import_button.clicked.connect(lambda: self.import_side_subgait('next'))
-        self.next_subgait_view.default_checkbox.stateChanged.connect(
-            lambda value: self.toggle_side_subgait_checkbox(value, self.next_subgait_controller, 'next', 'standing'))
-        self.next_subgait_view.lock_checkbox.stateChanged.connect(
-            lambda value: self.toggle_side_subgait_checkbox(value, self.next_subgait_controller, 'next', 'lock'))
+        for side in self.side_subgait_controller.keys():
+            self.view.side_subgait_view[side].import_button.clicked.connect(lambda: self.import_side_subgait(side))
+            self.view.side_subgait_view[side].default_checkbox.stateChanged.connect(
+                lambda value: self.toggle_side_subgait_checkbox(value, side, 'standing'))
+            self.view.side_subgait_view[side].lock_checkbox.stateChanged.connect(
+                lambda value: self.toggle_side_subgait_checkbox(value, side, 'lock'))
 
         self.view.start_button.clicked.connect(self.start_time_slider_thread)
         self.view.stop_button.clicked.connect(self.stop_time_slider_thread)
@@ -197,7 +189,7 @@ class GaitGeneratorController(object):
 
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
-        self.save_changed_settings({'joints': [self.subgait.joints]})
+        self.save_changed_settings({'joints': self.subgait.joints})
 
         self.subgait.set_duration(duration, rescale_setpoints)
         self.view.time_slider.setRange(0, 100 * self.subgait.duration)
@@ -238,7 +230,7 @@ class GaitGeneratorController(object):
         self.settings_changed_history = RingBuffer(capacity=100, dtype=list)
         self.settings_changed_redo_list = RingBuffer(capacity=100, dtype=list)
 
-    def import_side_subgait(self, position='previous'):
+    def import_side_subgait(self, side='previous'):
         file_name, f = self.view.open_file_dialogue()
 
         subgait = ModifiableSubgait.from_file(self.robot, file_name, self)
@@ -246,9 +238,9 @@ class GaitGeneratorController(object):
             rospy.logwarn('Could not load gait %s', file_name)
             return
 
-        if position == 'previous':
+        if side == 'previous':
             self.previous_subgait = subgait
-        elif position == 'next':
+        elif side == 'next':
             self.next_subgait = subgait
 
     def export_gait(self):
@@ -366,19 +358,21 @@ class GaitGeneratorController(object):
         self.settings_changed_redo_list = RingBuffer(capacity=100, dtype=list)
 
     # Functions related to previous/next subgait
-    def toggle_side_subgait_checkbox(self, value, side_subgait_controller, side, box_type):
-        self.save_changed_settings({'joints': self.subgait.joints, 'side_subgaits': [side_subgait_controller]})
+    def toggle_side_subgait_checkbox(self, value, side, box_type):
+        self.save_changed_settings({'joints': self.subgait.joints,
+                                    'side_subgaits': [self.side_subgait_controller['side']]})
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
         if box_type == 'lock':
-            side_subgait_controller.lock_checked = value
+            self.side_subgait_controller['side'].lock_checked = value
         elif box_type == 'standing':
-            side_subgait_controller.default_checked = value
-        self.handle_sidepoint_lock(side_subgait_controller, side)
+            self.side_subgait_controller['side'].default_checked = value
+        self.handle_sidepoint_lock(side)
 
-    def handle_sidepoint_lock(self, side_subgait_controller, side):
-        if side_subgait_controller.lock_checked and side_subgait_controller.subgait is not None:
-            for joint, side_subgait_joint in zip(self.subgait.joints, side_subgait_controller.subgait.joints):
+    def handle_sidepoint_lock(self, side):
+        if self.side_subgait_controller[side].lock_checked and self.side_subgait_controller[side].subgait is not None:
+            for joint, side_subgait_joint in zip(self.subgait.joints,
+                                                 self.side_subgait_controller[side].subgait.joints):
                 if side == 'previous':
                     joint.start_point = side_subgait_joint.setpoints[-1]
                 elif side == 'next':
@@ -396,24 +390,26 @@ class GaitGeneratorController(object):
 
     @property
     def previous_subgait(self):
-        return self.previous_subgait_controller.subgait
+        return self.side_subgait_controller['previous'].subgait
 
     @previous_subgait.setter
     def previous_subgait(self, new_subgait):
-        self.save_changed_settings({'joints': self.subgait.joints, 'side_subgaits': [self.previous_subgait_controller]})
+        self.save_changed_settings({'joints': self.subgait.joints,
+                                    'side_subgaits': [self.side_subgait_controller['previous']]})
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
-        self.previous_subgait_controller.subgait = new_subgait
-        self.handle_sidepoint_lock(self.previous_subgait_controller, 'previous')
+        self.side_subgait_controller['previous'].subgait = new_subgait
+        self.handle_sidepoint_lock('previous')
 
     @property
     def next_subgait(self):
-        return self.next_subgait_controller.subgait
+        return self.side_subgait_controller['next'].subgait
 
     @next_subgait.setter
     def next_subgait(self, new_subgait):
-        self.save_changed_settings({'joints': self.subgait.joints, 'side_subgaits': [self.next_subgait_controller]})
+        self.save_changed_settings({'joints': self.subgait.joints,
+                                    'side_subgaits': [self.side_subgait_controller['next']]})
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
-        self.next_subgait_controller.subgait = new_subgait
-        self.handle_sidepoint_lock(self.next_subgait_controller, 'next')
+        self.side_subgait_controller['next'].subgait = new_subgait
+        self.handle_sidepoint_lock('next')

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -353,20 +353,20 @@ class GaitGeneratorController(object):
         self.settings_changed_history.append(changed_dict)
 
     # Needed for undo and redo.
-    def save_changed_settings(self, joints):
-        self.settings_changed_history.append(joints)
+    def save_changed_settings(self, settings):
+        self.settings_changed_history.append(settings)
         self.settings_changed_redo_list = RingBuffer(capacity=100, dtype=list)
 
     # Functions related to previous/next subgait
     def toggle_side_subgait_checkbox(self, value, side, box_type):
         self.save_changed_settings({'joints': self.subgait.joints,
-                                    'side_subgaits': [self.side_subgait_controller['side']]})
+                                    'side_subgaits': [self.side_subgait_controller[side]]})
         for joint in self.subgait.joints:
             joint.save_setpoints(single_joint_change=False)
         if box_type == 'lock':
-            self.side_subgait_controller['side'].lock_checked = value
+            self.side_subgait_controller[side].lock_checked = value
         elif box_type == 'standing':
-            self.side_subgait_controller['side'].default_checked = value
+            self.side_subgait_controller[side].default_checked = value
         self.handle_sidepoint_lock(side)
 
     def handle_sidepoint_lock(self, side):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
@@ -17,6 +17,7 @@ from tf import (ConnectivityException, ExtrapolationException, LookupException,
 
 from .joint_plot import JointPlot
 from .joint_table_controller import JointTableController
+from .side_subgait_view import SideSubgaitView
 from .time_slider_thread import TimeSliderThread
 
 
@@ -36,6 +37,10 @@ class GaitGeneratorView(QWidget):
         self.RvizFrame.layout().addWidget(self.rviz_frame, 1, 0, 1, 3)
 
         self.gait_type_combo_box.addItems(['walk_like', 'sit_like', 'stairs_like'])
+
+        previous_subgait_view = SideSubgaitView(widget=self.view.previous_subgait_container)
+        next_subgait_view = SideSubgaitView(widget=self.view.next_subgait_container)
+        self.side_subgait_view = {'previous': previous_subgait_view, 'next': next_subgait_view}
 
         self.initialize_shortcuts()
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
@@ -125,13 +125,13 @@ class GaitGeneratorView(QWidget):
         return joint_plot_widget
 
     # Methods below are called during runtime
-    def publish_preview(self, gait, time):
+    def publish_preview(self, subgait, time):
         joint_state = JointState()
         joint_state.header.stamp = rospy.get_rostime()
 
-        for i in range(len(gait.joints)):
-            joint_state.name.append(gait.joints[i].name)
-            joint_state.position.append(gait.joints[i].get_interpolated_position(time))
+        for joint in subgait.joints:
+            joint_state.name.append(joint.name)
+            joint_state.position.append(joint.get_interpolated_position(time))
         self.joint_state_pub.publish(joint_state)
         self.set_feet_distances()
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
@@ -185,24 +185,6 @@ class GaitGeneratorView(QWidget):
         self.duration_spin_box.setValue(duration)
         self.duration_spin_box.blockSignals(False)
 
-    def update_side_subgait_widgets(self, previous_subgait_controller, next_subgait_controller):
-        self.import_previous_subgait_button.setText(previous_subgait_controller.subgait_text)
-        self.import_next_subgait_button.setText(next_subgait_controller.subgait_text)
-
-        self.previous_is_standing_check_box.blockSignals(True)
-        self.lock_startpoint_check_box.blockSignals(True)
-        self.previous_is_standing_check_box.setChecked(previous_subgait_controller.default_checked)
-        self.lock_startpoint_check_box.setChecked(previous_subgait_controller.lock_checked)
-        self.previous_is_standing_check_box.blockSignals(False)
-        self.lock_startpoint_check_box.blockSignals(False)
-
-        self.next_is_standing_check_box.blockSignals(True)
-        self.lock_endpoint_check_box.blockSignals(True)
-        self.next_is_standing_check_box.setChecked(next_subgait_controller.default_checked)
-        self.lock_endpoint_check_box.setChecked(next_subgait_controller.lock_checked)
-        self.next_is_standing_check_box.blockSignals(False)
-        self.lock_endpoint_check_box.blockSignals(False)
-
     @staticmethod
     def notify(title, message):
         subprocess.Popen(['notify-send', str(title), str(message)])

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
@@ -185,6 +185,24 @@ class GaitGeneratorView(QWidget):
         self.duration_spin_box.setValue(duration)
         self.duration_spin_box.blockSignals(False)
 
+    def update_side_subgait_widgets(self, previous_subgait_controller, next_subgait_controller):
+        self.import_previous_subgait_button.setText(previous_subgait_controller.subgait_text)
+        self.import_next_subgait_button.setText(next_subgait_controller.subgait_text)
+
+        self.previous_is_standing_check_box.blockSignals(True)
+        self.lock_startpoint_check_box.blockSignals(True)
+        self.previous_is_standing_check_box.setChecked(previous_subgait_controller.default_checked)
+        self.lock_startpoint_check_box.setChecked(previous_subgait_controller.lock_checked)
+        self.previous_is_standing_check_box.blockSignals(False)
+        self.lock_startpoint_check_box.blockSignals(False)
+
+        self.next_is_standing_check_box.blockSignals(True)
+        self.lock_endpoint_check_box.blockSignals(True)
+        self.next_is_standing_check_box.setChecked(next_subgait_controller.default_checked)
+        self.lock_endpoint_check_box.setChecked(next_subgait_controller.lock_checked)
+        self.next_is_standing_check_box.blockSignals(False)
+        self.lock_endpoint_check_box.blockSignals(False)
+
     @staticmethod
     def notify(title, message):
         subprocess.Popen(['notify-send', str(title), str(message)])

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_view.py
@@ -38,8 +38,8 @@ class GaitGeneratorView(QWidget):
 
         self.gait_type_combo_box.addItems(['walk_like', 'sit_like', 'stairs_like'])
 
-        previous_subgait_view = SideSubgaitView(widget=self.view.previous_subgait_container)
-        next_subgait_view = SideSubgaitView(widget=self.view.next_subgait_container)
+        previous_subgait_view = SideSubgaitView(widget=self.previous_subgait_container)
+        next_subgait_view = SideSubgaitView(widget=self.next_subgait_container)
         self.side_subgait_view = {'previous': previous_subgait_view, 'next': next_subgait_view}
 
         self.initialize_shortcuts()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
@@ -142,8 +142,8 @@ class ModifiableJointTrajectory(JointTrajectory):
         self._start_point = setpoints['start_point']
         self._end_point = setpoints['end_point']
         self._duration = self.setpoints[-1].time
-        self.interpolated_setpoints = self.interpolate_setpoints()
         self.enforce_limits()
+        self.interpolated_setpoints = self.interpolate_setpoints()
 
     def redo(self):
         if not self.setpoints_redo_list:
@@ -156,8 +156,8 @@ class ModifiableJointTrajectory(JointTrajectory):
         self._start_point = setpoints['start_point']
         self._end_point = setpoints['end_point']
         self._duration = self.setpoints[-1].time
-        self.interpolated_setpoints = self.interpolate_setpoints()
         self.enforce_limits()
+        self.interpolated_setpoints = self.interpolate_setpoints()
 
     @property
     def start_point(self):
@@ -169,6 +169,7 @@ class ModifiableJointTrajectory(JointTrajectory):
         if start_point:
             self._start_point.time = 0
         self.enforce_limits()
+        self.interpolated_setpoints = self.interpolate_setpoints()
 
     @property
     def end_point(self):
@@ -180,3 +181,4 @@ class ModifiableJointTrajectory(JointTrajectory):
         if end_point:
             self._end_point.time = self.duration
         self.enforce_limits()
+        self.interpolated_setpoints = self.interpolate_setpoints()

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
@@ -122,7 +122,7 @@ class ModifiableJointTrajectory(JointTrajectory):
         self.setpoints_history.append({'setpoints': copy.deepcopy(self.setpoints), 'start_point': self.start_point,
                                        'end_point': self.end_point})
         if single_joint_change:
-            self.gait_generator.save_changed_joints({'joints': [self]})
+            self.gait_generator.save_changed_settings({'joints': [self]})
 
     def invert(self):
         self.save_setpoints(single_joint_change=False)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
@@ -132,7 +132,6 @@ class ModifiableJointTrajectory(JointTrajectory):
         self.interpolated_setpoints = self.interpolate_setpoints()
 
     def undo(self):
-
         if not self.setpoints_history:
             return
 
@@ -142,6 +141,7 @@ class ModifiableJointTrajectory(JointTrajectory):
         self.setpoints = setpoints['setpoints']
         self._start_point = setpoints['start_point']
         self._end_point = setpoints['end_point']
+        self._duration = self.setpoints[-1].time
         self.interpolated_setpoints = self.interpolate_setpoints()
         self.enforce_limits()
 
@@ -155,6 +155,7 @@ class ModifiableJointTrajectory(JointTrajectory):
         self.setpoints = setpoints['setpoints']
         self._start_point = setpoints['start_point']
         self._end_point = setpoints['end_point']
+        self._duration = self.setpoints[-1].time
         self.interpolated_setpoints = self.interpolate_setpoints()
         self.enforce_limits()
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -173,3 +173,37 @@ class ModifiableSubgait(Subgait):
             joint.duration = duration
 
         self.duration = duration
+
+    def set_previous_subgait(self, previous_subgait):
+        if previous_subgait:
+            for joint, previous_joint in zip(self.joints, previous_subgait.joints):
+                joint.start_point = previous_joint.setpoints[-1]
+        else:
+            for joint in self.joints:
+                joint.start_point = None
+
+    def set_next_subgait(self, next_subgait):
+        if next_subgait:
+            for joint, next_joint in zip(self.joints, next_subgait.joints):
+                joint.end_point = next_joint.setpoints[0]
+        else:
+            for joint in self.joints:
+                joint.end_point = None
+
+    @property
+    def previous_subgait(self):
+        return self._previous_subgait
+
+    @previous_subgait.setter
+    def previous_subgait(self, new_subgait):
+        self.view.import_previous_subgait_button.setText(new_subgait.version)
+        self._previous_subgait = new_subgait
+
+    @property
+    def next_subgait(self):
+        return self._next_subgait
+
+    @next_subgait.setter
+    def next_subgait(self, new_subgait):
+        self.view.import_next_subgait_button.setText(new_subgait.version)
+        self._next_subgait = new_subgait

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -173,37 +173,3 @@ class ModifiableSubgait(Subgait):
             joint.duration = duration
 
         self.duration = duration
-
-    def set_previous_subgait(self, previous_subgait):
-        if previous_subgait:
-            for joint, previous_joint in zip(self.joints, previous_subgait.joints):
-                joint.start_point = previous_joint.setpoints[-1]
-        else:
-            for joint in self.joints:
-                joint.start_point = None
-
-    def set_next_subgait(self, next_subgait):
-        if next_subgait:
-            for joint, next_joint in zip(self.joints, next_subgait.joints):
-                joint.end_point = next_joint.setpoints[0]
-        else:
-            for joint in self.joints:
-                joint.end_point = None
-
-    @property
-    def previous_subgait(self):
-        return self._previous_subgait
-
-    @previous_subgait.setter
-    def previous_subgait(self, new_subgait):
-        self.view.import_previous_subgait_button.setText(new_subgait.version)
-        self._previous_subgait = new_subgait
-
-    @property
-    def next_subgait(self):
-        return self._next_subgait
-
-    @next_subgait.setter
-    def next_subgait(self, new_subgait):
-        self.view.import_next_subgait_button.setText(new_subgait.version)
-        self._next_subgait = new_subgait

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
@@ -69,4 +69,4 @@ class SideSubgaitController(object):
         if self._subgait:
             return self._subgait.version
         else:
-            return "Import"
+            return 'Import'

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
@@ -1,0 +1,70 @@
+from numpy_ringbuffer import RingBuffer
+
+from .model.modifiable_subgait import ModifiableSubgait
+
+
+class SideSubgaitController(object):
+    def __init__(self, default, lock_checked=False, default_checked=False, subgait=None):
+        self._lock_checked = lock_checked
+        self._default_checked = default_checked
+        self._subgait = subgait
+        self._default = default
+
+        self.settings_history = RingBuffer(capacity=100, dtype=list)
+        self.settings_redo_list = RingBuffer(capacity=100, dtype=list)
+
+    def undo(self):
+        self.settings_redo_list.append({'lock_checked': self._lock_checked, 'default_checked': self._default_checked,
+                                        'subgait': self._subgait})
+        settings = self.settings_history.pop()
+        self._lock_checked = settings['lock_checked']
+        self._default_checked = settings['default_checked']
+        self._subgait = settings['subgait']
+
+    def redo(self):
+        self.save_changed_settings()
+        settings = self.settings_redo_list.pop()
+        self._lock_checked = settings['lock_checked']
+        self._default_checked = settings['default_checked']
+        self._subgait = settings['subgait']
+
+    def save_changed_settings(self):
+        self.settings_history.append({'lock_checked': self._lock_checked, 'default_checked': self._default_checked,
+                                      'subgait': self._subgait})
+
+    @property
+    def lock_checked(self):
+        return self._lock_checked
+
+    @lock_checked.setter
+    def lock_checked(self, lock_checked):
+        self.save_changed_settings()
+        self._lock_checked = lock_checked
+
+    @property
+    def default_checked(self):
+        return self._default_checked
+
+    @default_checked.setter
+    def default_checked(self, default_checked):
+        self.save_changed_settings()
+        self._default_checked = default_checked
+
+    @property
+    def subgait(self):
+        if self.default_checked:
+            return self._default
+        else:
+            return self._subgait
+
+    @subgait.setter
+    def subgait(self, subgait):
+        self.save_changed_settings()
+        self._subgait = subgait
+
+    @property
+    def subgait_text(self):
+        if self._subgait:
+            return self._subgait.version
+        else:
+            return "Import"

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
@@ -41,6 +41,7 @@ class SideSubgaitController(object):
     def lock_checked(self, lock_checked):
         self.save_changed_settings()
         self._lock_checked = lock_checked
+        self.view.update_widget(self)
 
     @property
     def default_checked(self):
@@ -50,6 +51,7 @@ class SideSubgaitController(object):
     def default_checked(self, default_checked):
         self.save_changed_settings()
         self._default_checked = default_checked
+        self.view.update_widget(self)
 
     @property
     def subgait(self):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_controller.py
@@ -1,14 +1,13 @@
 from numpy_ringbuffer import RingBuffer
 
-from .model.modifiable_subgait import ModifiableSubgait
-
 
 class SideSubgaitController(object):
-    def __init__(self, default, lock_checked=False, default_checked=False, subgait=None):
+    def __init__(self, default, view, lock_checked=False, default_checked=False, subgait=None):
         self._lock_checked = lock_checked
         self._default_checked = default_checked
         self._subgait = subgait
         self._default = default
+        self.view = view
 
         self.settings_history = RingBuffer(capacity=100, dtype=list)
         self.settings_redo_list = RingBuffer(capacity=100, dtype=list)
@@ -20,6 +19,7 @@ class SideSubgaitController(object):
         self._lock_checked = settings['lock_checked']
         self._default_checked = settings['default_checked']
         self._subgait = settings['subgait']
+        self.view.update_widget(self)
 
     def redo(self):
         self.save_changed_settings()
@@ -27,6 +27,7 @@ class SideSubgaitController(object):
         self._lock_checked = settings['lock_checked']
         self._default_checked = settings['default_checked']
         self._subgait = settings['subgait']
+        self.view.update_widget(self)
 
     def save_changed_settings(self):
         self.settings_history.append({'lock_checked': self._lock_checked, 'default_checked': self._default_checked,
@@ -61,6 +62,7 @@ class SideSubgaitController(object):
     def subgait(self, subgait):
         self.save_changed_settings()
         self._subgait = subgait
+        self.view.update_widget(self)
 
     @property
     def subgait_text(self):

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_view.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/side_subgait_view.py
@@ -1,0 +1,19 @@
+from python_qt_binding.QtWidgets import (QCheckBox, QPushButton)
+
+
+class SideSubgaitView(object):
+    def __init__(self, widget):
+        self.import_button = widget.findChildren(QPushButton)[0]
+        self.default_checkbox = widget.findChildren(QCheckBox)[0]
+        self.lock_checkbox = widget.findChildren(QCheckBox)[1]
+
+    def update_widget(self, controller):
+        self.import_button.setText(controller.subgait_text)
+
+        self.lock_checkbox.blockSignals(True)
+        self.lock_checkbox.setChecked(controller.lock_checked)
+        self.lock_checkbox.blockSignals(False)
+
+        self.default_checkbox.blockSignals(True)
+        self.default_checkbox.setChecked(controller.default_checked)
+        self.default_checkbox.blockSignals(False)

--- a/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
+++ b/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
@@ -328,7 +328,6 @@ class GaitGeneratorControllerTest(unittest.TestCase):
     def test_undo_duration_changed(self):
         self.gait_generator_view.scale_setpoints_check_box.isChecked = Mock(return_value=False)
         self.gait_generator_controller.update_gait_duration(self.duration + 1)
-        print(self.gait_generator_controller.settings_changed_history)
         self.gait_generator_controller.undo()
         self.assertEqual(self.gait_generator_controller.subgait.duration, self.duration)
         self.gait_generator_view.set_duration_spinbox.assert_called_once_with(self.duration)

--- a/march_rqt_gait_generator/test/nosetests/modifiable_joint_trajectory_test.py
+++ b/march_rqt_gait_generator/test/nosetests/modifiable_joint_trajectory_test.py
@@ -92,7 +92,7 @@ class ModifiableJointTrajectoryTest(unittest.TestCase):
     def test_add_setpoint_save_changed_joints_call(self):
         new_setpoint = ModifiableSetpoint(0.5, 0, 0)
         self.joint_trajectory.add_setpoint(new_setpoint)
-        self.gait_generator.save_changed_joints.assert_called_once_with([self.joint_trajectory])
+        self.gait_generator.save_changed_settings.assert_called_once_with({'joints': [self.joint_trajectory]})
 
     # remove_setpoint tests
     def test_remove_setpoint_removal_correct_setpoint(self):
@@ -106,21 +106,21 @@ class ModifiableJointTrajectoryTest(unittest.TestCase):
 
     def test_remove_setpoint_save_changed_joints_call(self):
         self.joint_trajectory.remove_setpoint(2)
-        self.gait_generator.save_changed_joints.assert_called_once_with([self.joint_trajectory])
+        self.gait_generator.save_changed_settings.assert_called_once_with({'joints': [self.joint_trajectory]})
 
     # save_setpoints test
     def test_save_setpoints_content(self):
         self.joint_trajectory.save_setpoints()
-        old_setpoints = self.joint_trajectory.setpoints_history[0]
+        old_setpoints = self.joint_trajectory.setpoints_history[0]['setpoints']
         self.assertEqual(old_setpoints, self.setpoints)
 
     def test_save_setpoints_save_changed_joints_call(self):
         self.joint_trajectory.save_setpoints()
-        self.gait_generator.save_changed_joints.assert_called_once_with([self.joint_trajectory])
+        self.gait_generator.save_changed_settings.assert_called_once_with({'joints': [self.joint_trajectory]})
 
     def test_save_setpoints_no_save_changed_joints_call(self):
         self.joint_trajectory.save_setpoints(single_joint_change=False)
-        self.gait_generator.save_changed_joints.assert_not_called()
+        self.gait_generator.save_changed_settings.assert_not_called()
 
     # invert tests
     def test_invert_test_symmetric_times(self):
@@ -133,8 +133,8 @@ class ModifiableJointTrajectoryTest(unittest.TestCase):
 
     def test_invert_test_setpoints_saved(self):
         self.joint_trajectory.invert()
-        self.assertEqual(self.joint_trajectory.setpoints_history[0], self.setpoints)
-        self.gait_generator.save_changed_joints.assert_not_called()
+        self.assertEqual(self.joint_trajectory.setpoints_history[0]['setpoints'], self.setpoints)
+        self.gait_generator.save_changed_settings.assert_not_called()
 
     # undo tests
     def test_undo_empty_history(self):

--- a/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v2.subgait
@@ -126,7 +126,7 @@ trajectory:
         nsecs: 990000000
     - 
       positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 

--- a/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v2.subgait
@@ -126,7 +126,7 @@ trajectory:
         nsecs: 990000000
     - 
       positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
+      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
       accelerations: []
       effort: []
       time_from_start: 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-480

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

It is now possible to lock the end and startpoint of a subgait to ensure good transition to imported side subgaits. Any change to the side subgait buttons/checkboxes can be undone. 

_Damn that undo functionality took so much more time than the rest..._

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

* Added classes SideSubgaitController and SideSubgaitView to handle the view and storage of the side subgaits. This will allow easy extension to more side subgaits if this ever becomes applicable.
* Added logic to lock the start and endpoint of the subgait currently being edited.
* Added logic to allow undo/redo of locking start/end points.
* Wrote tests for new functionality.


<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
