### PR TITLE
Fix setpoints pointer problems

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
@@ -82,9 +82,12 @@ class ModifiableJointTrajectory(JointTrajectory):
 
     def enforce_limits(self):
         if self.start_point:
-            self.setpoints[0] = self.start_point
+            self.setpoints[0].position = self.start_point.position
+            self.setpoints[0].velocity = self.start_point.velocity
         if self.end_point:
-            self.setpoints[-1] = self.end_point
+            self.setpoints[-1].position = self.end_point.position
+            self.setpoints[-1].velocity = self.end_point.velocity
+
         self.setpoints[0].time = 0
         self.setpoints[-1].time = self.duration
 
@@ -166,8 +169,6 @@ class ModifiableJointTrajectory(JointTrajectory):
     @start_point.setter
     def start_point(self, start_point):
         self._start_point = start_point
-        if start_point:
-            self._start_point.time = 0
         self.enforce_limits()
         self.interpolated_setpoints = self.interpolate_setpoints()
 
@@ -178,7 +179,5 @@ class ModifiableJointTrajectory(JointTrajectory):
     @end_point.setter
     def end_point(self, end_point):
         self._end_point = end_point
-        if end_point:
-            self._end_point.time = self.duration
         self.enforce_limits()
         self.interpolated_setpoints = self.interpolate_setpoints()


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

There was a bug in https://github.com/project-march/gait-generation/pull/100 that caused a crash when doing lock -> invert -> lock. It had something to do with pointers to setpoints which got messy when start en end point got changed around by invert. Hence, I simply set position and velocity to be equal here, instead of assigning `setpoints[0] = start_point` etc.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
