### PR TITLE
Feature: new subgait format

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -212,12 +212,11 @@ class GaitGeneratorController(object):
     def import_gait(self):
         file_name, f = self.view.open_file_dialogue()
 
-        gait = ModifiableSubgait.from_file(self.robot, file_name)
+        gait = ModifiableSubgait.from_file(self.robot, file_name, self)
         if gait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return
         self.subgait = gait
-        self.subgait.set_gait_generator(self)
 
         was_playing = self.time_slider_thread is not None
         self.stop_time_slider_thread()
@@ -241,11 +240,10 @@ class GaitGeneratorController(object):
     def import_side_subgait(self, side='previous'):
         file_name, f = self.view.open_file_dialogue()
 
-        subgait = ModifiableSubgait.from_file(self.robot, file_name)
+        subgait = ModifiableSubgait.from_file(self.robot, file_name, self)
         if subgait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return
-        subgait.set_gait_generator(self)
 
         if side == 'previous':
             self.previous_subgait = subgait

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -212,11 +212,12 @@ class GaitGeneratorController(object):
     def import_gait(self):
         file_name, f = self.view.open_file_dialogue()
 
-        gait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        gait = ModifiableSubgait.from_file(self.robot, file_name)
         if gait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return
         self.subgait = gait
+        self.subgait.set_gait_generator(self)
 
         was_playing = self.time_slider_thread is not None
         self.stop_time_slider_thread()
@@ -268,8 +269,6 @@ class GaitGeneratorController(object):
         if gait_directory is None or gait_directory == '':
             return
 
-        subgait_msg = subgait.to_subgait_msg()
-
         output_file_directory = os.path.join(gait_directory,
                                              subgait.gait_name.replace(' ', '_'),
                                              subgait.subgait_name.replace(' ', '_'))
@@ -289,7 +288,7 @@ class GaitGeneratorController(object):
             os.makedirs(output_file_directory)
 
         with open(output_file_path, 'w') as output_file:
-            output_file.write(str(subgait_msg))
+            output_file.write(subgait.to_yaml())
 
         self.view.notify('Gait Saved', output_file_path)
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -241,10 +241,11 @@ class GaitGeneratorController(object):
     def import_side_subgait(self, side='previous'):
         file_name, f = self.view.open_file_dialogue()
 
-        subgait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        subgait = ModifiableSubgait.from_file(self.robot, file_name)
         if subgait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return
+        subgait.set_gait_generator(self)
 
         if side == 'previous':
             self.previous_subgait = subgait

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_joint_trajectory.py
@@ -28,9 +28,6 @@ class ModifiableJointTrajectory(JointTrajectory):
             rospy.logwarn('Last setpoint of {0} has been set '
                           'from {1} to {2}'.format(name, self.setpoints[0].time, duration))
 
-    def set_gait_generator(self, gait_generator):
-        self.gait_generator = gait_generator
-
     def set_setpoints(self, setpoints):
         self.setpoints = setpoints
 

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -52,10 +52,6 @@ class ModifiableSubgait(Subgait):
         return cls(joint_list, duration, gait_type='walk_like', gait_name='test_gait', subgait_name='test_subgait',
                    version='test_subgait_1', description='Just a simple gait')
 
-    def set_gait_generator(self, gait_generator):
-        for joint in self.joints:
-            joint.set_gait_generator(gait_generator)
-
     def has_multiple_setpoints_before_duration(self, duration):
         """Check if all setpoints are before a given duration."""
         return not any(joint.setpoints[1].time > duration for joint in self.joints)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -54,6 +54,10 @@ class ModifiableSubgait(Subgait):
         return cls(joint_list, duration, gait_type='walk_like', gait_name='test_gait', subgait_name='test_subgait',
                    version='test_subgait_1', description='Just a simple gait')
 
+    def set_gait_generator(self, gait_generator):
+        for joint in self.joints:
+            joint.set_gait_generator(gait_generator)
+
     def has_multiple_setpoints_before_duration(self, duration):
         """Check if all setpoints are before a given duration."""
         return not any(joint.setpoints[1].time > duration for joint in self.joints)

--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/model/modifiable_subgait.py
@@ -27,9 +27,7 @@ class ModifiableSubgait(Subgait):
             return None
 
         joint_list = []
-        for joint_index in range(len(robot.joints)):
-            urdf_joint = robot.joints[joint_index]
-
+        for urdf_joint in sorted(robot.joints, key=lambda j: j.name):
             if urdf_joint.type == 'fixed':
                 rospy.loginfo('Skipping fixed joint ' + urdf_joint.name)
                 continue

--- a/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
+++ b/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
@@ -24,6 +24,7 @@ class GaitGeneratorControllerTest(unittest.TestCase):
         self.duration = self.gait_generator_controller.subgait.duration
         self.num_joints = len(self.gait_generator_controller.subgait.joints)
 
+        self.maxDiff = None
         self.gait_name = 'walk'
         self.subgait_name = 'left_swing'
         self.version = 'MV_walk_leftswing_v2'

--- a/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
+++ b/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
@@ -24,7 +24,6 @@ class GaitGeneratorControllerTest(unittest.TestCase):
         self.duration = self.gait_generator_controller.subgait.duration
         self.num_joints = len(self.gait_generator_controller.subgait.joints)
 
-        self.maxDiff = None
         self.gait_name = 'walk'
         self.subgait_name = 'left_swing'
         self.version = 'MV_walk_leftswing_v2'

--- a/march_rqt_gait_generator/test/nosetests/modifiable_subgait_test.py
+++ b/march_rqt_gait_generator/test/nosetests/modifiable_subgait_test.py
@@ -21,8 +21,7 @@ class ModifiableSubgaitTest(unittest.TestCase):
                                                                               gait=self.gait_name,
                                                                               subgait=self.subgait_name,
                                                                               version=self.version)
-        self.subgait = ModifiableSubgait.from_file(self.robot, self.subgait_path)
-        self.subgait.set_gait_generator(self.gait_generator)
+        self.subgait = ModifiableSubgait.from_file(self.robot, self.subgait_path, self.gait_generator)
 
     # empty_subgait tests
     def test_empty_subgait_type(self):

--- a/march_rqt_gait_generator/test/nosetests/modifiable_subgait_test.py
+++ b/march_rqt_gait_generator/test/nosetests/modifiable_subgait_test.py
@@ -21,8 +21,8 @@ class ModifiableSubgaitTest(unittest.TestCase):
                                                                               gait=self.gait_name,
                                                                               subgait=self.subgait_name,
                                                                               version=self.version)
-        self.subgait = ModifiableSubgait.from_file(self.robot, self.subgait_path, self.gait_generator)
-        self.subgait_msg = self.subgait.to_subgait_msg()
+        self.subgait = ModifiableSubgait.from_file(self.robot, self.subgait_path)
+        self.subgait.set_gait_generator(self.gait_generator)
 
     # empty_subgait tests
     def test_empty_subgait_type(self):

--- a/march_rqt_gait_generator/test/resources/walk/left_close/MIV_final.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_close/MIV_final.subgait
@@ -1,123 +1,83 @@
-name: ''
-version: ''
-description: "Final left step of the MIV walking gait."
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:  38800000
-    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.1619, 0.1474, 0.0436, 0.0, 0.2774, 0.1394, 0.0436]
-      velocities: [0.0, 0.2625, 0.4268, 0.0, 0.0, -0.3521, -0.0086, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:  38800000
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, -0.0, 0.0, -0.2837, -0.1166, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, 0.0, 0.0, -0.2479, -0.1255, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, 0.0, 0.0, -0.2274, -0.1289, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, 0.0, 0.0, 0.0, -0.1303, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: Final left step of the MIV walking gait.
+duration: {nsecs: 550000000, secs: 1}
+gait_type: ''
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 38800000, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id005 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: &id003 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id005
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.288
+    time_from_start: *id003
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: left_close
+version: MIV_final

--- a/march_rqt_gait_generator/test/resources/walk/left_close/MV_walk_leftclose_v1.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_close/MV_walk_leftclose_v1.subgait
@@ -1,112 +1,83 @@
-name: ''
-version: ''
-description: "The same gait as MIV, but with a somewhat larger step."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: The same gait as MIV, but with a somewhat larger step.
+duration: {nsecs: 550000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.3142
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: left_close
+version: MV_walk_leftclose_v1

--- a/march_rqt_gait_generator/test/resources/walk/left_close/MV_walk_leftclose_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_close/MV_walk_leftclose_v2.subgait
@@ -1,112 +1,83 @@
-name: ''
-version: ''
-description: "Final left step of the MIV walking gait."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.2837, -0.1166, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2479, -0.1255, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2274, -0.1289, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: Final left step of the MIV walking gait.
+duration: {nsecs: 550000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.288
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: left_close
+version: MV_walk_leftclose_v2

--- a/march_rqt_gait_generator/test/resources/walk/left_swing/MIV_final.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_swing/MIV_final.subgait
@@ -1,150 +1,90 @@
-name: ''
-version: ''
-description: "The setpoints of this walking gait are the same as the setpoints of the MIV, but\
-  \ less flexion of the hip"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_fe, left_knee, right_hip_fe, right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:  30000000
-    joint_names: [left_hip_aa, left_ankle, right_hip_aa, right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 240000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 450000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 504000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 600000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 720000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 816000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  80000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 199999999
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.1652, 0.1431, 0.0436, 0.0, 0.2808, 0.141, 0.0436]
-      velocities: [0.0, 0.1075, 0.2559, 0.0, 0.0, -0.36, 0.1036, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:  30000000
-    - 
-      positions: [0.0, -0.0113, 0.4667, 0.0436, 0.0, 0.19, 0.2094, 0.0436]
-      velocities: [0.0, 1.1376, 2.1631, -0.0, 0.0, -0.4718, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 240000000
-    - 
-      positions: [0.0, 0.2634, 0.8471, 0.0436, 0.0, 0.0841, 0.1888, 0.0436]
-      velocities: [0.0, 1.2804, 0.9364, 0.0, 0.0, -0.5058, -0.1657, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 450000000
-    - 
-      positions: [0.0, 0.3257, 0.8727, 0.0436, 0.0, 0.0584, 0.1799, 0.0436]
-      velocities: [0.0, 1.1836, 0.0, 0.0, 0.0, -0.5024, -0.1791, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 504000000
-    - 
-      positions: [0.0, 0.4285, 0.8152, 0.0436, 0.0, 0.0083, 0.1617, 0.0436]
-      velocities: [0.0, 0.8392, -1.074, 0.0, 0.0, -0.4825, -0.1719, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 600000000
-    - 
-      positions: [0.0, 0.4887, 0.6425, 0.0436, 0.0, -0.0433, 0.1456, 0.0436]
-      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.4403, -0.1117, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 720000000
-    - 
-      positions: [0.0, 0.4824, 0.4413, 0.0436, 0.0, -0.0851, 0.1396, 0.0436]
-      velocities: [0.0, -0.2331, -2.0135, 0.0, 0.0, -0.3834, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 816000000
-    - 
-      positions: [0.0, 0.3472, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
-      velocities: [0.0, -0.5857, 0.0, 0.0, 0.0, -0.1531, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  80000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 199999999
-duration: 
-  secs: 1
-  nsecs: 199999999
-sounds: []
+description: The setpoints of this walking gait are the same as the setpoints of the
+  MIV, but less flexion of the hip
+duration: {nsecs: 199999999, secs: 1}
+gait_type: ''
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 30000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 199999999, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 450000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id005 {nsecs: 600000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: &id003 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 720000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start: *id002
+    velocity: -0.3491
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 504000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 80000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id005
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.288
+    time_from_start: *id003
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 240000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 816000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: left_swing
+version: MIV_final

--- a/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v1.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v1.subgait
@@ -1,138 +1,89 @@
-name: ''
-version: ''
-description: "The same gait as MIV, but with a somewhat larger step."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 240000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 450000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 504000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 600000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 720000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 816000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  80000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 199999999
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
-      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 240000000
-    - 
-      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
-      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 450000000
-    - 
-      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
-      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 504000000
-    - 
-      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
-      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 600000000
-    - 
-      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
-      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 720000000
-    - 
-      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
-      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 816000000
-    - 
-      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
-      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  80000000
-    - 
-      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 199999999
-duration: 
-  secs: 1
-  nsecs: 199999999
-sounds: []
+description: The same gait as MIV, but with a somewhat larger step.
+duration: {nsecs: 199999999, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 199999999, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 450000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 600000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 720000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.3142
+    time_from_start: *id002
+    velocity: -0.3491
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 504000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 80000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: 0.3142
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 240000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 816000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: left_swing
+version: MV_walk_leftswing_v1

--- a/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/left_swing/MV_walk_leftswing_v2.subgait
@@ -1,138 +1,141 @@
-name: "left_swing"
-version: "MV_walk_leftswing_v2"
-description: "The MIV walking gait, but with a somewhat faster swing."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 220000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 412500000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 462000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 550000000
-    joint_names: [left_hip_aa, right_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 660000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 748000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 990000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 100000000
-    joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [left_hip_aa, left_hip_fe, left_knee, left_ankle, right_hip_aa, right_hip_fe, right_knee,
-  right_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.0036, 0.48, 0.0436, 0.0, 0.1916, 0.2094, 0.0436]
-      velocities: [0.0, 1.2775, 2.3748, 0.0, 0.0, -0.5085, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 220000000
-    - 
-      positions: [0.0, 0.2678, 0.8493, 0.0436, 0.0, 0.0879, 0.1883, 0.0436]
-      velocities: [0.0, 1.3855, 0.9108, 0.0, 0.0, -0.554, -0.1838, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 412500000
-    - 
-      positions: [0.0, 0.3336, 0.8727, 0.0436, 0.0, 0.0605, 0.1789, 0.0436]
-      velocities: [0.0, 1.261, 0.0, 0.0, 0.0, -0.5515, -0.1969, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 462000000
-    - 
-      positions: [0.0, 0.4295, 0.8152, 0.0436, 0.0, 0.0126, 0.1617, 0.0436]
-      velocities: [0.0, 0.8857, -1.2244, 0.0, 0.0, -0.5328, -0.1859, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 550000000
-    - 
-      positions: [0.0, 0.4887, 0.6272, 0.0436, 0.0, -0.0435, 0.1448, 0.0436]
-      velocities: [0.0, 0.1396, -2.0662, 0.0, 0.0, -0.4835, -0.1102, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 660000000
-    - 
-      positions: [0.0, 0.4806, 0.4364, 0.0436, 0.0, -0.0836, 0.1396, 0.0436]
-      velocities: [0.0, -0.2955, -2.1887, 0.0, 0.0, -0.4235, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 748000000
-    - 
-      positions: [0.0, 0.3438, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
-      velocities: [0.0, -0.6222, 0.0, 0.0, 0.0, -0.1639, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 990000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 100000000
-duration: 
-  secs: 1
+description: The MIV walking gait, but with a somewhat faster swing.
+duration:
   nsecs: 100000000
-sounds: []
+  secs: 1
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 412500000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 550000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  left_hip_fe:
+  - position: -0.1667
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start:
+      nsecs: 660000000
+      secs: 0
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: -0.3491
+  left_knee:
+  - position: 0.1396
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start:
+      nsecs: 462000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start:
+      nsecs: 990000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 412500000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 550000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_hip_fe:
+  - position: 0.288
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start:
+      nsecs: 220000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 748000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+name: left_swing
+version: MV_walk_leftswing_v2

--- a/march_rqt_gait_generator/test/resources/walk/right_close/MIV_final.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_close/MIV_final.subgait
@@ -1,123 +1,83 @@
-name: ''
-version: ''
-description: "Final right step of the MIV walking gait with less hip flexion"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:  38800000
-    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.1619, 0.1474, 0.0436, 0.0, 0.2774, 0.1394, 0.0436]
-      velocities: [0.0, 0.2625, 0.4268, 0.0, 0.0, -0.3521, -0.0086, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:  38800000
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, -0.0, 0.0, -0.2837, -0.1166, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, 0.0, 0.0, -0.2479, -0.1255, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, 0.0, 0.0, -0.2274, -0.1289, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, 0.0, 0.0, 0.0, -0.1303, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: Final right step of the MIV walking gait with less hip flexion
+duration: {nsecs: 550000000, secs: 1}
+gait_type: ''
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 38800000, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id005 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start: &id003 {nsecs: 0, secs: 0}
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id005
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: right_close
+version: MIV_final

--- a/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v1.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v1.subgait
@@ -1,112 +1,83 @@
-name: ''
-version: ''
-description: "The same gait as MIV, but with a somewhat larger step."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1334, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.3259, -0.1166, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1088, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2881, -0.1255, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0978, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2656, -0.1289, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0643, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1515, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: The same gait as MIV, but with a somewhat larger step.
+duration: {nsecs: 550000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.3142
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: right_close
+version: MV_walk_rightclose_v1

--- a/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v2.subgait
@@ -1,112 +1,83 @@
-name: ''
-version: ''
-description: "Final right step of the MIV walking gait with less hip flexion"
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062, 0.0436]
-      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.2837, -0.1166, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964, 0.0436]
-      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2479, -0.1255, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912, 0.0436]
-      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2274, -0.1289, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698, 0.0436]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497, 0.0436]
-      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: Final right step of the MIV walking gait with less hip flexion
+duration: {nsecs: 550000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: right_close
+version: MV_walk_rightclose_v2

--- a/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v2_seven_joints.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_close/MV_walk_rightclose_v2_seven_joints.subgait
@@ -1,109 +1,76 @@
-name: ''
-version: ''
-description: "Final right step of the MIV walking gait with less hip flexion"
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 496000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 581200000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 620000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 775000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 930000000
-    joint_names: [left_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 550000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.4687, 0.8727, 0.0436, 0.0, 0.1215, 0.1062]
-      velocities: [0.0, 1.2147, 0.0, 0.0, 0.0, -0.2837, -0.1166]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 496000000
-    - 
-      positions: [0.0, 0.5414, 0.8592, 0.0436, 0.0, 0.1002, 0.0964]
-      velocities: [0.0, 0.629, -0.3189, -0.0, 0.0, -0.2479, -0.1255]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 581200000
-    - 
-      positions: [0.0, 0.5585, 0.8424, 0.0436, 0.0, 0.0908, 0.0912]
-      velocities: [0.0, 0.1396, -0.4752, -0.0, 0.0, -0.2274, -0.1289]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 620000000
-    - 
-      positions: [0.0, 0.5257, 0.7216, 0.0436, 0.0, 0.0623, 0.0698]
-      velocities: [0.0, -0.503, -0.9556, -0.0, 0.0, -0.1274, -0.1351]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 775000000
-    - 
-      positions: [0.0, 0.414, 0.5555, 0.0436, 0.0, 0.0524, 0.0497]
-      velocities: [0.0, -0.9092, -1.1954, -0.0, 0.0, 0.0, -0.1303]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 930000000
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 550000000
-duration: 
-  secs: 1
-  nsecs: 550000000
-sounds: []
+description: Final right step of the MIV walking gait with less hip flexion
+duration: {nsecs: 550000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 581200000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 775000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id002 {nsecs: 550000000, secs: 1}
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: 0.0524
+    time_from_start: {nsecs: 930000000, secs: 0}
+    velocity: 0.0
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 620000000, secs: 0}
+    velocity: 0.1396
+  - position: -0.0873
+    time_from_start: *id002
+    velocity: 0.0
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 496000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: 0.0
+name: right_close
+version: MV_walk_rightclose_v2_seven_joints

--- a/march_rqt_gait_generator/test/resources/walk/right_open/MIV_final.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_open/MIV_final.subgait
@@ -1,136 +1,86 @@
-name: ''
-version: ''
-description: "The right open gait for the MIV walking gait with less hip flexion"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:  37600000
-    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 562400000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 630000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 750000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 900000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  20000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 350000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 500000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.0855, 0.0058, 0.0436, 0.0, -0.0874, 0.0004, 0.0436]
-      velocities: [0.0, 0.0969, 0.3186, 0.0, 0.0, -0.0052, 0.0198, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:  37600000
-    - 
-      positions: [0.0, 0.2802, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
-      velocities: [0.0, 0.8993, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 562400000
-    - 
-      positions: [0.0, 0.341, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
-      velocities: [0.0, 0.8305, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 630000000
-    - 
-      positions: [0.0, 0.4285, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
-      velocities: [0.0, 0.615, -0.8363, -0.0, 0.0, -0.0794, 0.1636, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 750000000
-    - 
-      positions: [0.0, 0.4887, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
-      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 900000000
-    - 
-      positions: [0.0, 0.4858, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
-      velocities: [0.0, -0.1603, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  20000000
-    - 
-      positions: [0.0, 0.3532, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
-      velocities: [0.0, -0.4872, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 350000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 500000000
-duration: 
-  secs: 1
-  nsecs: 500000000
-sounds: []
+description: The right open gait for the MIV walking gait with less hip flexion
+duration: {nsecs: 500000000, secs: 1}
+gait_type: ''
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 37600000, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 562400000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id005 {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: &id003 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 20000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id005
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 900000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start: *id002
+    velocity: -0.3491
+  right_knee:
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 630000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 350000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: right_open
+version: MIV_final

--- a/march_rqt_gait_generator/test/resources/walk/right_open/MV_walk_rightopen_v1.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_open/MV_walk_rightopen_v1.subgait
@@ -1,125 +1,86 @@
-name: ''
-version: ''
-description: "The same gait as MIV, but with a somewhat larger step."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 562400000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 630000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 750000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 900000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  20000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 350000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 500000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.3269, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
-      velocities: [0.0, 1.01, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 562400000
-    - 
-      positions: [0.0, 0.3952, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
-      velocities: [0.0, 0.9304, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 630000000
-    - 
-      positions: [0.0, 0.4928, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
-      velocities: [0.0, 0.683, -0.8363, 0.0, 0.0, -0.0794, 0.1636, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 750000000
-    - 
-      positions: [0.0, 0.5585, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
-      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 900000000
-    - 
-      positions: [0.0, 0.5513, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
-      velocities: [0.0, -0.2264, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  20000000
-    - 
-      positions: [0.0, 0.3863, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
-      velocities: [0.0, -0.5711, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 350000000
-    - 
-      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 500000000
-duration: 
-  secs: 1
-  nsecs: 500000000
-sounds: []
+description: The same gait as MIV, but with a somewhat larger step.
+duration: {nsecs: 500000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 562400000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: *id001
+    velocity: 0.0
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 20000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 900000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.3142
+    time_from_start: *id002
+    velocity: -0.3491
+  right_knee:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 630000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 350000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: right_open
+version: MV_walk_rightopen_v1

--- a/march_rqt_gait_generator/test/resources/walk/right_open/MV_walk_rightopen_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_open/MV_walk_rightopen_v2.subgait
@@ -1,125 +1,86 @@
-name: ''
-version: ''
-description: "The right open gait for the MIV walking gait with less hip flexion"
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 562400000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 630000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 750000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 900000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  20000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 350000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 500000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.0873, 0.0, 0.0436, 0.0, -0.0873, 0.0, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.2802, 0.8374, 0.0436, 0.0, -0.1118, 0.0787, 0.0436]
-      velocities: [0.0, 0.8993, 0.9344, -0.0, 0.0, -0.0737, 0.2041, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 562400000
-    - 
-      positions: [0.0, 0.341, 0.8727, 0.0436, 0.0, -0.1171, 0.0928, 0.0436]
-      velocities: [0.0, 0.8305, 0.0, -0.0, 0.0, -0.077, 0.1959, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 630000000
-    - 
-      positions: [0.0, 0.4285, 0.8197, 0.0436, 0.0, -0.1266, 0.1146, 0.0436]
-      velocities: [0.0, 0.615, -0.8363, 0.0, 0.0, -0.0794, 0.1636, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 750000000
-    - 
-      positions: [0.0, 0.4887, 0.6333, 0.0436, 0.0, -0.1384, 0.1339, 0.0436]
-      velocities: [0.0, 0.1396, -1.4938, 0.0, 0.0, -0.0766, 0.0907, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 900000000
-    - 
-      positions: [0.0, 0.4858, 0.4416, 0.0436, 0.0, -0.1473, 0.1396, 0.0436]
-      velocities: [0.0, -0.1603, -1.6102, 0.0, 0.0, -0.0697, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  20000000
-    - 
-      positions: [0.0, 0.3532, 0.0969, 0.0436, 0.0, -0.1644, 0.1396, 0.0436]
-      velocities: [0.0, -0.4872, 0.0, 0.0, 0.0, -0.0296, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 350000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 500000000
-duration: 
-  secs: 1
-  nsecs: 500000000
-sounds: []
+description: The right open gait for the MIV walking gait with less hip flexion
+duration: {nsecs: 500000000, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 500000000, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 562400000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 750000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: -0.0873
+    time_from_start: *id001
+    velocity: 0.0
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 20000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.0873
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 900000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start: *id002
+    velocity: -0.3491
+  right_knee:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 630000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 350000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: right_open
+version: MV_walk_rightopen_v2

--- a/march_rqt_gait_generator/test/resources/walk/right_swing/MIV_final.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_swing/MIV_final.subgait
@@ -1,150 +1,90 @@
-name: ''
-version: ''
-description: "The setpoints of this walking gait are the same as the setpoints of the MIV, but\
-  \ less flexion of the hip"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_fe, right_knee, left_hip_fe, left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:  30000000
-    joint_names: [right_hip_aa, right_ankle, left_hip_aa, left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 240000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 450000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 504000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 600000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 720000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 816000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  80000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 199999999
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [-0.0, 0.0, 0.0, -0.0, -0.0, -0.3491, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.1652, 0.1431, 0.0436, 0.0, 0.2808, 0.141, 0.0436]
-      velocities: [0.0, 0.1075, 0.2559, 0.0, 0.0, -0.36, 0.1036, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:  30000000
-    - 
-      positions: [0.0, -0.0113, 0.4667, 0.0436, 0.0, 0.19, 0.2094, 0.0436]
-      velocities: [0.0, 1.1376, 2.1631, -0.0, 0.0, -0.4718, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 240000000
-    - 
-      positions: [0.0, 0.2634, 0.8471, 0.0436, 0.0, 0.0841, 0.1888, 0.0436]
-      velocities: [0.0, 1.2804, 0.9364, 0.0, 0.0, -0.5058, -0.1657, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 450000000
-    - 
-      positions: [0.0, 0.3257, 0.8727, 0.0436, 0.0, 0.0584, 0.1799, 0.0436]
-      velocities: [0.0, 1.1836, 0.0, 0.0, 0.0, -0.5024, -0.1791, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 504000000
-    - 
-      positions: [0.0, 0.4285, 0.8152, 0.0436, 0.0, 0.0083, 0.1617, 0.0436]
-      velocities: [0.0, 0.8392, -1.074, 0.0, 0.0, -0.4825, -0.1719, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 600000000
-    - 
-      positions: [0.0, 0.4887, 0.6425, 0.0436, 0.0, -0.0433, 0.1456, 0.0436]
-      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.4403, -0.1117, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 720000000
-    - 
-      positions: [0.0, 0.4824, 0.4413, 0.0436, 0.0, -0.0851, 0.1396, 0.0436]
-      velocities: [0.0, -0.2331, -2.0135, 0.0, 0.0, -0.3834, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 816000000
-    - 
-      positions: [0.0, 0.3472, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
-      velocities: [0.0, -0.5857, 0.0, 0.0, 0.0, -0.1531, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  80000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 199999999
-duration: 
-  secs: 1
-  nsecs: 199999999
-sounds: []
+description: The setpoints of this walking gait are the same as the setpoints of the
+  MIV, but less flexion of the hip
+duration: {nsecs: 199999999, secs: 1}
+gait_type: ''
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 30000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 199999999, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 450000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id005 {nsecs: 600000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start: &id003 {nsecs: 0, secs: 0}
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 240000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 816000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id005
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start: {nsecs: 720000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start: *id002
+    velocity: -0.3491
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 504000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 80000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: right_swing
+version: MIV_final

--- a/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v1.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v1.subgait
@@ -1,138 +1,89 @@
-name: ''
-version: ''
-description: "The same gait as MIV, but with a somewhat larger step."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 240000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 450000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 504000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 600000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 720000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 816000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs:  80000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 199999999
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.3142, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, 0.006, 0.4667, 0.0436, 0.0, 0.2136, 0.2094, 0.0436]
-      velocities: [0.0, 1.2637, 2.1631, 0.0, 0.0, -0.492, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 240000000
-    - 
-      positions: [0.0, 0.3107, 0.8471, 0.0436, 0.0, 0.102, 0.1888, 0.0436]
-      velocities: [0.0, 1.4182, 0.9364, 0.0, 0.0, -0.5363, -0.1657, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 450000000
-    - 
-      positions: [0.0, 0.3798, 0.8727, 0.0436, 0.0, 0.0748, 0.1799, 0.0436]
-      velocities: [0.0, 1.3091, 0.0, 0.0, 0.0, -0.5342, -0.1791, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 504000000
-    - 
-      positions: [0.0, 0.4931, 0.8152, 0.0436, 0.0, 0.0214, 0.1617, 0.0436]
-      velocities: [0.0, 0.9226, -1.074, 0.0, 0.0, -0.5153, -0.1719, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 600000000
-    - 
-      positions: [0.0, 0.5585, 0.6425, 0.0436, 0.0, -0.0338, 0.1456, 0.0436]
-      velocities: [0.0, 0.1396, -1.8432, 0.0, 0.0, -0.472, -0.1117, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 720000000
-    - 
-      positions: [0.0, 0.5479, 0.4413, 0.0436, 0.0, -0.0787, 0.1396, 0.0436]
-      velocities: [0.0, -0.315, -2.0135, 0.0, 0.0, -0.4122, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 816000000
-    - 
-      positions: [0.0, 0.3805, 0.0969, 0.0436, 0.0, -0.1567, 0.1396, 0.0436]
-      velocities: [0.0, -0.6918, 0.0, 0.0, 0.0, -0.1655, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs:  80000000
-    - 
-      positions: [0.0, 0.3142, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [-0.0, -0.3491, 0.0, -0.0, -0.0, 0.0, 0.0, -0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 199999999
-duration: 
-  secs: 1
-  nsecs: 199999999
-sounds: []
+description: The same gait as MIV, but with a somewhat larger step.
+duration: {nsecs: 199999999, secs: 1}
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start: &id001 {nsecs: 0, secs: 0}
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: &id002 {nsecs: 199999999, secs: 1}
+    velocity: -0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id003 {nsecs: 450000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: &id004 {nsecs: 600000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  left_hip_fe:
+  - position: 0.3142
+    time_from_start: *id001
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start: *id002
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start: {nsecs: 240000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: {nsecs: 816000000, secs: 0}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id003
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id004
+    velocity: 0.0
+  - position: 0.0
+    time_from_start: *id002
+    velocity: -0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.5585
+    time_from_start: {nsecs: 720000000, secs: 0}
+    velocity: 0.1396
+  - position: 0.3142
+    time_from_start: *id002
+    velocity: -0.3491
+  right_knee:
+  - position: 0.1396
+    time_from_start: *id001
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start: {nsecs: 504000000, secs: 0}
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start: {nsecs: 80000000, secs: 1}
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start: *id002
+    velocity: 0.0
+name: right_swing
+version: MV_walk_rightswing_v1

--- a/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v2.subgait
+++ b/march_rqt_gait_generator/test/resources/walk/right_swing/MV_walk_rightswing_v2.subgait
@@ -1,138 +1,141 @@
-name: "right_swing"
-version: "MV_walk_rightswing_v2"
-description: "The MIV walking gait, but with a somewhat faster swing."
-gait_type: "walk_like"
-setpoints: 
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs:         0
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 220000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 412500000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 462000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 550000000
-    joint_names: [right_hip_aa, left_hip_aa]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 660000000
-    joint_names: [right_hip_fe]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 748000000
-    joint_names: [left_knee]
-  - 
-    time_from_start: 
-      secs: 0
-      nsecs: 990000000
-    joint_names: [right_knee]
-  - 
-    time_from_start: 
-      secs: 1
-      nsecs: 100000000
-    joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-trajectory: 
-  header: 
-    seq: 0
-    stamp: 
-      secs: 0
-      nsecs:         0
-    frame_id: ''
-  joint_names: [right_hip_aa, right_hip_fe, right_knee, right_ankle, left_hip_aa, left_hip_fe, left_knee,
-  left_ankle]
-  points: 
-    - 
-      positions: [0.0, -0.1667, 0.1396, 0.0436, 0.0, 0.288, 0.1396, 0.0436]
-      velocities: [0.0, 0.0, 0.0, 0.0, 0.0, -0.3491, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs:         0
-    - 
-      positions: [0.0, -0.0036, 0.48, 0.0436, 0.0, 0.1916, 0.2094, 0.0436]
-      velocities: [0.0, 1.2775, 2.3748, 0.0, 0.0, -0.5085, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 220000000
-    - 
-      positions: [0.0, 0.2678, 0.8493, 0.0436, 0.0, 0.0879, 0.1883, 0.0436]
-      velocities: [0.0, 1.3855, 0.9108, 0.0, 0.0, -0.554, -0.1838, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 412500000
-    - 
-      positions: [0.0, 0.3336, 0.8727, 0.0436, 0.0, 0.0605, 0.1789, 0.0436]
-      velocities: [0.0, 1.261, 0.0, 0.0, 0.0, -0.5515, -0.1969, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 462000000
-    - 
-      positions: [0.0, 0.4295, 0.8152, 0.0436, 0.0, 0.0126, 0.1617, 0.0436]
-      velocities: [0.0, 0.8857, -1.2244, 0.0, 0.0, -0.5328, -0.1859, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 550000000
-    - 
-      positions: [0.0, 0.4887, 0.6272, 0.0436, 0.0, -0.0435, 0.1448, 0.0436]
-      velocities: [0.0, 0.1396, -2.0662, 0.0, 0.0, -0.4835, -0.1102, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 660000000
-    - 
-      positions: [0.0, 0.4806, 0.4364, 0.0436, 0.0, -0.0836, 0.1396, 0.0436]
-      velocities: [0.0, -0.2955, -2.1887, 0.0, 0.0, -0.4235, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 748000000
-    - 
-      positions: [0.0, 0.3438, 0.0969, 0.0436, 0.0, -0.1574, 0.1396, 0.0436]
-      velocities: [0.0, -0.6222, 0.0, 0.0, 0.0, -0.1639, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 0
-        nsecs: 990000000
-    - 
-      positions: [0.0, 0.288, 0.1396, 0.0436, 0.0, -0.1667, 0.1396, 0.0436]
-      velocities: [0.0, -0.3491, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-      accelerations: []
-      effort: []
-      time_from_start: 
-        secs: 1
-        nsecs: 100000000
-duration: 
-  secs: 1
+description: The MIV walking gait, but with a somewhat faster swing.
+duration:
   nsecs: 100000000
-sounds: []
+  secs: 1
+gait_type: walk_like
+joints:
+  left_ankle:
+  - position: 0.0436
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  left_hip_aa:
+  - position: 0.0
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 412500000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 550000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  left_hip_fe:
+  - position: 0.288
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: -0.3491
+  - position: -0.1667
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  left_knee:
+  - position: 0.1396
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.2094
+    time_from_start:
+      nsecs: 220000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 748000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_ankle:
+  - position: 0.0436
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0436
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_hip_aa:
+  - position: 0.0
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 412500000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 550000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+  right_hip_fe:
+  - position: -0.1667
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.4887
+    time_from_start:
+      nsecs: 660000000
+      secs: 0
+    velocity: 0.1396
+  - position: 0.288
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: -0.3491
+  right_knee:
+  - position: 0.1396
+    time_from_start:
+      nsecs: 0
+      secs: 0
+    velocity: 0.0
+  - position: 0.8727
+    time_from_start:
+      nsecs: 462000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.0969
+    time_from_start:
+      nsecs: 990000000
+      secs: 0
+    velocity: 0.0
+  - position: 0.1396
+    time_from_start:
+      nsecs: 100000000
+      secs: 1
+    velocity: 0.0
+name: right_swing
+version: MV_walk_rightswing_v2


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-500

## Description
This PR introduces fixes to work with the new subgait format, see project-march/march#549.

In the main PR I removed the `*args` from `JointTrajectoryController.__init__`, since I thought it did nothing, but the subclass used it for passing the gait generator. Instead, I have added a new setter, because I felt like the first was not a clean solution. Let me know what you think.

## Changes
* Remove the custom `from_dict` in `ModifiableJointTrajectory`, since it now exclusively uses setpoints
* Export subgaits using the new `to_yaml` method
* Changed test subgait files to new format (project-march/gait-files#188)

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
