### PR TITLE
Fix error when canceling import

### DIFF
--- a/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
+++ b/march_rqt_gait_generator/src/march_rqt_gait_generator/gait_generator_controller.py
@@ -217,7 +217,11 @@ class GaitGeneratorController(object):
     def import_gait(self):
         file_name, f = self.view.open_file_dialogue()
 
-        gait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        if file_name != '':
+            gait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        else:
+            gait = None
+
         if gait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return
@@ -247,7 +251,11 @@ class GaitGeneratorController(object):
     def import_side_subgait(self, side='previous'):
         file_name, f = self.view.open_file_dialogue()
 
-        subgait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        if file_name != '':
+            subgait = ModifiableSubgait.from_file(self.robot, file_name, self)
+        else:
+            subgait = None
+
         if subgait is None:
             rospy.logwarn('Could not load gait %s', file_name)
             return

--- a/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
+++ b/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
@@ -186,7 +186,7 @@ class GaitGeneratorControllerTest(unittest.TestCase):
         try:
             self.gait_generator_controller.import_gait()
         except FileNotFoundError:
-            self.fail("Import gait raised FileNotFoundError")
+            self.fail('Import gait raised FileNotFoundError')
 
     def test_import_gait(self):
         self.gait_generator_view.open_file_dialogue = Mock(return_value=(self.subgait_path, None))
@@ -394,7 +394,7 @@ class GaitGeneratorControllerTest(unittest.TestCase):
         try:
             self.gait_generator_controller.import_side_subgait('previous')
         except FileNotFoundError:
-            self.fail("Import side subgait raised FileNotFoundError")
+            self.fail('Import side subgait raised FileNotFoundError')
 
     def test_import_previous_subgait_lock_start(self):
         self.gait_generator_view.open_file_dialogue = Mock(return_value=(self.subgait_path, None))

--- a/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
+++ b/march_rqt_gait_generator/test/nosetests/gait_generator_controller_test.py
@@ -180,6 +180,14 @@ class GaitGeneratorControllerTest(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             self.gait_generator_controller.import_gait()
 
+    def test_import_gait_cancel(self):
+        self.gait_generator_view.open_file_dialogue = Mock(return_value=('', None))
+
+        try:
+            self.gait_generator_controller.import_gait()
+        except FileNotFoundError:
+            self.fail("Import gait raised FileNotFoundError")
+
     def test_import_gait(self):
         self.gait_generator_view.open_file_dialogue = Mock(return_value=(self.subgait_path, None))
 
@@ -379,6 +387,14 @@ class GaitGeneratorControllerTest(unittest.TestCase):
 
         self.gait_generator_controller.import_side_subgait('next')
         self.assertEqual(self.gait_generator_controller.next_subgait.subgait_name, 'left_swing')
+
+    def test_import_side_subgait_cancel(self):
+        self.gait_generator_view.open_file_dialogue = Mock(return_value=('', None))
+
+        try:
+            self.gait_generator_controller.import_side_subgait('previous')
+        except FileNotFoundError:
+            self.fail("Import side subgait raised FileNotFoundError")
 
     def test_import_previous_subgait_lock_start(self):
         self.gait_generator_view.open_file_dialogue = Mock(return_value=(self.subgait_path, None))


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->


Closes PM-551

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
Canceling importing a gait no longer gives a FileNotFoundError

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
The import functions of the gait_generator_controller.py now check whether the file name is available after opening the open file dialogue

## Testing

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->

1. Open the gait generator
2. Import a gait and press cancel
3. The gait generator should not crash and the console should not present a FileNotFoundError
